### PR TITLE
Dont ignore FutureWarnings in tests

### DIFF
--- a/influxdb/dataframe_client.py
+++ b/influxdb/dataframe_client.py
@@ -55,15 +55,13 @@ class DataFrameClient(InfluxDBClient):
                         name=key,
                         dataframe=data_frame.ix[start_index:end_index].copy(),
                         time_precision=time_precision)]
-                    InfluxDBClient.write_points_with_precision(self, data,
-                                                               *args, **kwargs)
+                    InfluxDBClient.write_points(self, data, *args, **kwargs)
             return True
         else:
             data = [self._convert_dataframe_to_json(
                 name=key, dataframe=dataframe, time_precision=time_precision)
                 for key, dataframe in data.items()]
-            return InfluxDBClient.write_points_with_precision(self, data,
-                                                              *args, **kwargs)
+            return InfluxDBClient.write_points(self, data, *args, **kwargs)
 
     def write_points_with_precision(self, data, time_precision='s'):
         """

--- a/tests/influxdb/client_test.py
+++ b/tests/influxdb/client_test.py
@@ -62,8 +62,8 @@ def _mocked_session(method="GET", status_code=200, content=""):
 class TestInfluxDBClient(unittest.TestCase):
 
     def setUp(self):
-        # By default, ignore warnings
-        warnings.simplefilter('ignore', FutureWarning)
+        # By default, raise exceptions on warnings
+        warnings.simplefilter('error', FutureWarning)
 
         self.dummy_points = [
             {
@@ -92,7 +92,6 @@ class TestInfluxDBClient(unittest.TestCase):
 
     @raises(FutureWarning)
     def test_switch_db_deprecated(self):
-        warnings.simplefilter('error', FutureWarning)
         cli = InfluxDBClient('host', 8086, 'username', 'password', 'database')
         cli.switch_db('another_database')
         assert cli._database == 'another_database'
@@ -170,7 +169,7 @@ class TestInfluxDBClient(unittest.TestCase):
                 Exception,
                 "InfluxDB only supports seconds precision for udp writes"
         ):
-            cli.write_points_with_precision(
+            cli.write_points(
                 self.dummy_points,
                 time_precision='ms'
             )
@@ -184,7 +183,7 @@ class TestInfluxDBClient(unittest.TestCase):
     def test_write_points_with_precision(self):
         with _mocked_session('post', 200, self.dummy_points):
             cli = InfluxDBClient('host', 8086, 'username', 'password', 'db')
-            assert cli.write_points_with_precision(self.dummy_points) is True
+            assert cli.write_points(self.dummy_points) is True
 
     def test_write_points_bad_precision(self):
         cli = InfluxDBClient()
@@ -192,7 +191,7 @@ class TestInfluxDBClient(unittest.TestCase):
             Exception,
             "Invalid time precision is given. \(use 's', 'm', 'ms' or 'u'\)"
         ):
-            cli.write_points_with_precision(
+            cli.write_points(
                 self.dummy_points,
                 time_precision='g'
             )
@@ -325,7 +324,7 @@ class TestInfluxDBClient(unittest.TestCase):
         ]
         with _mocked_session('get', 200, data):
             cli = InfluxDBClient('host', 8086, 'username', 'password')
-            assert len(cli.get_database_list()) == 1
+            assert len(cli.get_list_database()) == 1
             assert cli.get_list_database()[0]['name'] == 'a_db'
 
     @raises(Exception)
@@ -336,7 +335,6 @@ class TestInfluxDBClient(unittest.TestCase):
 
     @raises(FutureWarning)
     def test_get_database_list_deprecated(self):
-        warnings.simplefilter('error', FutureWarning)
         data = [
             {"name": "a_db"}
         ]

--- a/tests/influxdb/dataframe_client_test.py
+++ b/tests/influxdb/dataframe_client_test.py
@@ -9,6 +9,7 @@ from nose.tools import raises
 from datetime import timedelta
 from tests import skipIfPYpy, using_pypy
 import copy
+import warnings
 
 if not using_pypy:
     import pandas as pd
@@ -20,6 +21,10 @@ from .client_test import _mocked_session
 
 @skipIfPYpy
 class TestDataFrameClient(unittest.TestCase):
+
+    def setUp(self):
+        # By default, raise exceptions on warnings
+        warnings.simplefilter('error', FutureWarning)
 
     def test_write_points_from_dataframe(self):
         now = pd.Timestamp('1970-01-01 00:00+00:00')


### PR DESCRIPTION
@timtroendle The DataFrameClient still used the now deprecated ``write_points_with_precision`` method. This commit fixes the issue.

Will you give me a thumbs up? :)