### PR TITLE
close response objects

### DIFF
--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -181,7 +181,7 @@ class InfluxDBClient(object):
             params=None,
             data=data,
             expected_response_code=200
-        )
+        ).close()
         return True
 
     # Writing Data
@@ -267,7 +267,7 @@ class InfluxDBClient(object):
                 params=params,
                 data=data,
                 expected_response_code=200
-            )
+            ).close()
 
         return True
 
@@ -283,7 +283,7 @@ class InfluxDBClient(object):
             url=url,
             method='DELETE',
             expected_response_code=204
-        )
+        ).close()
 
         return True
 
@@ -398,7 +398,7 @@ class InfluxDBClient(object):
             method='POST',
             data=data,
             expected_response_code=201
-        )
+        ).close()
 
         return True
 
@@ -418,7 +418,7 @@ class InfluxDBClient(object):
             url=url,
             method='DELETE',
             expected_response_code=204
-        )
+        ).close()
 
         return True
 
@@ -470,7 +470,7 @@ class InfluxDBClient(object):
             url=url,
             method='DELETE',
             expected_response_code=204
-        )
+        ).close()
 
         return True
 
@@ -556,7 +556,7 @@ class InfluxDBClient(object):
             method='POST',
             data=data,
             expected_response_code=200
-        )
+        ).close()
 
         return True
 
@@ -575,7 +575,7 @@ class InfluxDBClient(object):
             method='POST',
             data=data,
             expected_response_code=200
-        )
+        ).close()
 
         return True
 
@@ -589,7 +589,7 @@ class InfluxDBClient(object):
             url=url,
             method='DELETE',
             expected_response_code=200
-        )
+        ).close()
 
         return True
 
@@ -615,7 +615,7 @@ class InfluxDBClient(object):
             method='POST',
             data=data,
             expected_response_code=200
-        )
+        ).close()
 
         return True
 
@@ -717,7 +717,7 @@ class InfluxDBClient(object):
             method='POST',
             data=data,
             expected_response_code=200
-        )
+        ).close()
 
         return True
 
@@ -736,7 +736,7 @@ class InfluxDBClient(object):
             method='POST',
             data=data,
             expected_response_code=200
-        )
+        ).close()
 
         if username == self._username:
             self._password = new_password
@@ -753,7 +753,7 @@ class InfluxDBClient(object):
             url=url,
             method='DELETE',
             expected_response_code=200
-        )
+        ).close()
 
         return True
 

--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -168,7 +168,8 @@ class InfluxDBClient(object):
             timeout=self._timeout
         )
 
-        # consume all the data in order to release the connection back to the pool
+        # consume all the data in order to release 
+        # the connection back to the pool
         response.content
 
         if response.status_code == expected_response_code:

--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -168,6 +168,9 @@ class InfluxDBClient(object):
             timeout=self._timeout
         )
 
+        # consume all the data in order to release the connection back to the pool
+        response.content
+
         if response.status_code == expected_response_code:
             return response
         else:
@@ -181,7 +184,7 @@ class InfluxDBClient(object):
             params=None,
             data=data,
             expected_response_code=200
-        ).close()
+        )
         return True
 
     # Writing Data
@@ -267,7 +270,7 @@ class InfluxDBClient(object):
                 params=params,
                 data=data,
                 expected_response_code=200
-            ).close()
+            )
 
         return True
 
@@ -283,7 +286,7 @@ class InfluxDBClient(object):
             url=url,
             method='DELETE',
             expected_response_code=204
-        ).close()
+        )
 
         return True
 
@@ -398,7 +401,7 @@ class InfluxDBClient(object):
             method='POST',
             data=data,
             expected_response_code=201
-        ).close()
+        )
 
         return True
 
@@ -418,7 +421,7 @@ class InfluxDBClient(object):
             url=url,
             method='DELETE',
             expected_response_code=204
-        ).close()
+        )
 
         return True
 
@@ -470,7 +473,7 @@ class InfluxDBClient(object):
             url=url,
             method='DELETE',
             expected_response_code=204
-        ).close()
+        )
 
         return True
 
@@ -556,7 +559,7 @@ class InfluxDBClient(object):
             method='POST',
             data=data,
             expected_response_code=200
-        ).close()
+        )
 
         return True
 
@@ -575,7 +578,7 @@ class InfluxDBClient(object):
             method='POST',
             data=data,
             expected_response_code=200
-        ).close()
+        )
 
         return True
 
@@ -589,7 +592,7 @@ class InfluxDBClient(object):
             url=url,
             method='DELETE',
             expected_response_code=200
-        ).close()
+        )
 
         return True
 
@@ -615,7 +618,7 @@ class InfluxDBClient(object):
             method='POST',
             data=data,
             expected_response_code=200
-        ).close()
+        )
 
         return True
 
@@ -717,7 +720,7 @@ class InfluxDBClient(object):
             method='POST',
             data=data,
             expected_response_code=200
-        ).close()
+        )
 
         return True
 
@@ -736,7 +739,7 @@ class InfluxDBClient(object):
             method='POST',
             data=data,
             expected_response_code=200
-        ).close()
+        )
 
         if username == self._username:
             self._password = new_password
@@ -753,7 +756,7 @@ class InfluxDBClient(object):
             url=url,
             method='DELETE',
             expected_response_code=200
-        ).close()
+        )
 
         return True
 


### PR DESCRIPTION
Hi,

requests normally reuses the tcp connection for multiple requests, this is handy when feeding data to influx continuously. However to reuse the connection, previous response object has to be closed, this happens implicitly when its content is accessed (.text, .content, .json()). However, it has to be done manually when the data is ignored.

Don't know if this is the best way to patch it, though.

http://docs.python-requests.org/en/latest/user/advanced/#body-content-workflow
"Requests cannot release the connection back to the pool unless you consume all the data or call Response.close."