### PR TITLE
Dump directly to file

### DIFF
--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -371,7 +371,15 @@ class InfluxDBClient(object):
         else:
             with open(output_file, 'w') as f:
                 for chunk in resp.iter_content():
-                    if chunk: f.write(chunk)
+                    # if chuck has data, write to file.
+                    if chunk:
+                        # Write each chunk to its own line
+                        # this makes it nice and easy (via xreadlines()) to iterate through
+                        # each complete chunk and operate on it
+                        if chunk.endswith("}"):
+                            j.write(chunk + "\n")
+                        else:
+                            j.write(chunk)
             return True
 
     # Creating and Dropping Databases

--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -346,18 +346,13 @@ class InfluxDBClient(object):
             raise Exception(
                 "Invalid time precision is given. (use 's', 'm', 'ms' or 'u')")
 
-        if chunked is True:
-            chunked_param = 'true'
-        else:
-            chunked_param = 'false'
-
         # Build the URL of the serie to query
         url = "db/{0}/series".format(self._database)
 
         params = {
             'q': query,
             'time_precision': time_precision,
-            'chunked': chunked_param
+            'chunked': chunked.__str__().lower()
         }
 
         response = self.request(


### PR DESCRIPTION
This adds the ability to dump the results of a query directly to a file instead of storing in memory. This is usefully when you're pulling huge amounts of data from influxdb (ie several GBs). An example use case is a backup script that backs up influx data directly to disk.