### PR TITLE
Add a test module against a real running server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
 install:
     - sudo pip install tox
     - sudo pip install coveralls
+    - ./build_influxdb_server.sh
 script:
     - travis_wait tox -e $TOX_ENV
 after_success:

--- a/build_influxdb_server.sh
+++ b/build_influxdb_server.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+#
+# build and install,
+# the latest influxdb server master
+#
+
+set -e
+
+tmpdir=$(mktemp -d)
+
+echo "Using tempdir $tmpdir .."
+
+cd "$tmpdir"
+
+# rpm for package.sh (below) which will also build an .rpm
+sudo apt-get install ruby ruby-dev build-essential rpm
+
+echo $PATH
+echo $(which gem)
+echo $(which ruby)
+
+gem=$(which gem)
+
+sudo $gem install fpm
+
+mkdir -p go/src/github.com/influxdb
+cd go/src/github.com/influxdb
+
+git clone --depth 5 https://github.com/influxdb/influxdb
+cd influxdb
+
+version=0.0.0-$(git describe --always | sed 's/^v//')
+echo "describe: $version"
+
+export GOPATH="$tmpdir/go"
+{ echo y ; yes no ; } | ./package.sh "$version"
+
+deb=$(ls *.deb)
+sudo dpkg -i "$deb"

--- a/influxdb/_dataframe_client.py
+++ b/influxdb/_dataframe_client.py
@@ -68,7 +68,7 @@ class DataFrameClient(InfluxDBClient):
             FutureWarning)
         return self.write_points(data, time_precision='s')
 
-    def query(self, query, time_precision='s', chunked=False):
+    def query(self, query, time_precision='s', chunked=False, database=None):
         """
         Quering data into a DataFrame.
 

--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -19,6 +19,8 @@ session = requests.Session()
 class InfluxDBClientError(Exception):
     """Raised when an error occurs in the request"""
     def __init__(self, content, code):
+        if isinstance(content, type(b'')):
+            content = content.decode('UTF-8', errors='replace')
         super(InfluxDBClientError, self).__init__(
             "{0}: {1}".format(code, content))
         self.content = content

--- a/tests/influxdb/client_test.py
+++ b/tests/influxdb/client_test.py
@@ -1,6 +1,18 @@
 # -*- coding: utf-8 -*-
 """
-unit tests
+unit tests for the InfluxDBClient.
+
+NB/WARNING :
+This module implements tests for the InfluxDBClient class
+but does so
+ + without any server instance running
+ + by mocking all the expected responses.
+
+So any change of (response format from) the server will **NOT** be
+detected by this module.
+
+See client_test_with_server.py for tests against a running server instance.
+
 """
 import json
 import requests

--- a/tests/influxdb/client_test_with_server.py
+++ b/tests/influxdb/client_test_with_server.py
@@ -1,0 +1,513 @@
+# -*- coding: utf-8 -*-
+"""
+unit tests for checking the good/expected interaction between :
+
++ the python client.. (obviously)
++ and a *_real_* server instance running.
+
+This basically duplicates what's in client_test.py
+ but without mocking around every call.
+
+"""
+
+from __future__ import print_function
+
+import datetime
+import distutils.spawn
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+
+import warnings
+
+from influxdb import InfluxDBClient
+from influxdb.client import InfluxDBClientError
+
+from .misc import get_free_port, is_port_open
+
+
+THIS_DIR = os.path.abspath(os.path.dirname(__file__))
+
+
+# try to find where is located the 'influxd' binary:
+# You can define 'InfluxDbPythonClientTest_SERVER_BIN_PATH'
+#  env var to force it :
+influxdb_bin_path = influxdb_forced_bin = os.environ.get(
+    'InfluxDbPythonClientTest_SERVER_BIN_PATH', '')
+if not influxdb_bin_path:
+    try:
+        influxdb_bin_path = distutils.spawn.find_executable('influxd')
+        if not influxdb_bin_path:
+            raise Exception('not found via distutils')
+    except Exception as err:
+        try:
+            influxdb_bin_path = subprocess.check_output(
+                ['which', 'influxdb']).strip()
+        except subprocess.CalledProcessError as err:
+            # fallback on :
+            influxdb_bin_path = '/opt/influxdb/influxd'
+
+is_influxdb_bin_ok = (
+    # if the env var is set then consider the influxdb_bin as OK..
+    influxdb_forced_bin
+    or (os.path.isfile(influxdb_bin_path)
+        and os.access(influxdb_bin_path, os.X_OK))
+)
+
+if is_influxdb_bin_ok:
+    # read version :
+    version = subprocess.check_output([influxdb_bin_path, 'version'])
+    print(version, file=sys.stderr)
+
+
+dummy_point = [  # some dummy points .. :o
+    {
+        "name": "cpu_load_short",
+        "tags": {
+            "host": "server01",
+            "region": "us-west"
+        },
+        "timestamp": "2009-11-10T23:00:00Z",
+        "fields": {
+            "value": 0.64
+        }
+    }
+]
+
+dummy_points = [  # some dummy points .. :o
+    dummy_point[0],
+    {
+        "name": "memory",
+        "tags": {
+            "host": "server01",
+            "region": "us-west"
+        },
+        "timestamp": "2009-11-10T23:01:35Z",
+        "fields": {
+            "value": 33
+        }
+    }
+]
+
+dummy_point_without_timestamp = [
+    {
+        "name": "cpu_load_short",
+        "tags": {
+            "host": "server02",
+            "region": "us-west"
+        },
+        "fields": {
+            "value": 0.64
+        }
+    }
+]
+
+
+class InfluxDbInstance(object):
+
+    def __init__(self, conf_template):
+        # create a fresh temporary place for storing all needed files
+        # for the influxdb server instance :
+        self.temp_dir_base = tempfile.mkdtemp()
+        # "temp_dir_base" will be used for conf file and logs,
+        # while "temp_dir_influxdb" is for the databases files/dirs :
+        self.temp_dir_influxdb = tempfile.mkdtemp(
+            dir=self.temp_dir_base)
+        # we need some "free" ports :
+        self.broker_port = get_free_port()
+        self.admin_port = get_free_port()
+        # as it's UDP we can reuse the same port than the broker:
+        self.udp_port = get_free_port()
+
+        self.logs_file = os.path.join(
+            self.temp_dir_base, 'logs.txt')
+
+        with open(conf_template) as fh:
+            conf = fh.read().format(
+                broker_port=self.broker_port,
+                admin_port=self.admin_port,
+                udp_port=self.udp_port,
+                broker_raft_dir=os.path.join(
+                    self.temp_dir_influxdb, 'raft'),
+                broker_node_dir=os.path.join(
+                    self.temp_dir_influxdb, 'db'),
+                influxdb_cluster_dir=os.path.join(
+                    self.temp_dir_influxdb, 'state'),
+                influxdb_logfile=self.logs_file
+            )
+
+        conf_file = os.path.join(self.temp_dir_base, 'influxdb.conf')
+        with open(conf_file, "w") as fh:
+            fh.write(conf)
+
+        # now start the server instance:
+        proc = self.proc = subprocess.Popen(
+            [influxdb_bin_path, '-config', conf_file],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+        print("%s > Started influxdb bin in %r with ports %s and %s.." % (
+              datetime.datetime.now(),
+              self.temp_dir_base,
+              self.admin_port, self.broker_port))
+
+        # wait for it to listen on the broker and admin ports:
+        # usually a fresh instance is ready in less than 1 sec ..
+        timeout = time.time() + 10  # so 10 secs should be rather enough,
+        # otherwise either your system load is rather high,
+        # or you run a 286 @ 1Mhz ?
+        try:
+            while time.time() < timeout:
+                if (is_port_open(self.broker_port)
+                        and is_port_open(self.admin_port)):
+                    break
+                time.sleep(0.5)
+                if proc.poll() is not None:
+                    raise RuntimeError('influxdb prematurely exited')
+            else:
+                proc.terminate()
+                proc.wait()
+                raise RuntimeError('Timeout waiting for influxdb to listen'
+                                   ' on its broker port')
+        except RuntimeError as err:
+            data = self.get_logs_and_output()
+            data['reason'] = str(err)
+            data['now'] = datetime.datetime.now()
+            raise RuntimeError("%(now)s > %(reason)s. RC=%(rc)s\n"
+                               "stdout=%(out)r\nstderr=%(err)r\nlogs=%(logs)r"
+                               % data)
+
+    def get_logs_and_output(self):
+        proc = self.proc
+        with open(self.logs_file) as fh:
+            return {
+                'rc': proc.returncode,
+                'out': proc.stdout.read(),
+                'err': proc.stderr.read(),
+                'logs': fh.read()
+            }
+
+    def close(self, remove_tree=True):
+        self.proc.terminate()
+        self.proc.wait()
+        if remove_tree:
+            shutil.rmtree(self.temp_dir_base)
+
+
+class InfluxDbClientTestWithServerInstanceMixin(object):
+    ''' A mixin for unittest.TestCase to start an influxdb server instance
+    in a fresh temporary place.
+    '''
+
+    # 'influxdb_template_conf' attribute must be set on the class or instance
+
+    def setUp(self):
+        # By default, raise exceptions on warnings
+        warnings.simplefilter('error', FutureWarning)
+
+        self.influxd_inst = InfluxDbInstance(self.influxdb_template_conf)
+        self.cli = InfluxDBClient('localhost',
+                                  self.influxd_inst.broker_port,
+                                  'root', '', database='db')
+
+    def tearDown(self):
+        remove_tree = sys.exc_info() == (None, None, None)
+        self.influxd_inst.close(remove_tree=remove_tree)
+
+
+@unittest.skipIf(not is_influxdb_bin_ok, "not found any influxd binary")
+class TestInfluxDBClient(InfluxDbClientTestWithServerInstanceMixin,
+                         unittest.TestCase):
+
+    influxdb_template_conf = os.path.join(THIS_DIR, 'influxdb.conf.template')
+
+    def test_create_database(self):
+        self.assertIsNone(self.cli.create_database('new_db_1'))
+        self.assertIsNone(self.cli.create_database('new_db_2'))
+        self.assertEqual(
+            self.cli.get_list_database(),
+            ['new_db_1', 'new_db_2']
+        )
+
+    def test_create_database_fails(self):
+        self.assertIsNone(self.cli.create_database('new_db'))
+        with self.assertRaises(InfluxDBClientError) as ctx:
+            self.cli.create_database('new_db')
+        self.assertEqual(500, ctx.exception.code)
+        self.assertEqual('{"results":[{"error":"database exists"}]}',
+                         ctx.exception.content)
+
+    def test_drop_database(self):
+        self.test_create_database()
+        self.assertIsNone(self.cli.drop_database('new_db_1'))
+        self.assertEqual(['new_db_2'], self.cli.get_list_database())
+
+    def test_drop_database_fails(self):
+        with self.assertRaises(InfluxDBClientError) as ctx:
+            self.cli.drop_database('db')
+        self.assertEqual(500, ctx.exception.code)
+        self.assertEqual('{"results":[{"error":"database not found"}]}',
+                         ctx.exception.content)
+
+    def test_write(self):
+        new_dummy_point = dummy_point[0].copy()
+        new_dummy_point['database'] = 'db'
+        self.cli.create_database('db')
+        self.assertIs(True, self.cli.write(new_dummy_point))
+
+    @unittest.skip("fail against real server instance, "
+                   "don't know if it should succeed actually..")
+    def test_write_check_read(self):
+        self.test_write()
+        # hmmmm damn,
+        # after write has returned, if we directly query for the data it's not
+        #  directly available.. (don't know if this is expected behavior (
+        #   but it maybe))
+        # So we have to :
+        time.sleep(5)
+        # so that then the data is available through select :
+        rsp = self.cli.query('SELECT * FROM cpu_load_short', database='db')
+        self.assertEqual(
+            {'cpu_load_short': [
+                {'value': 0.64, 'time': '2009-11-10T23:00:00Z'}]},
+            rsp
+        )
+
+    def test_write_points(self):
+        ''' same as test_write() but with write_points \o/ '''
+        self.cli.create_database('db')
+        self.assertIs(True, self.cli.write_points(dummy_point))
+
+    def test_write_points_check_read(self):
+        ''' same as test_write_check_read() but with write_points \o/ '''
+        self.test_write_points()
+        time.sleep(1)  # same as test_write_check_read()
+        self.assertEqual(
+            {'cpu_load_short': [
+                {'value': 0.64, 'time': '2009-11-10T23:00:00Z'}]},
+            self.cli.query('SELECT * FROM cpu_load_short'))
+
+    def test_write_multiple_points_different_series(self):
+        self.cli.create_database('db')
+        self.assertIs(True, self.cli.write_points(dummy_points))
+        time.sleep(1)
+        self.assertEqual(
+            {'cpu_load_short': [
+                {'value': 0.64, 'time': '2009-11-10T23:00:00Z'}]},
+            self.cli.query('SELECT * FROM cpu_load_short'))
+        self.assertEqual(
+            {'memory': [
+                {'time': '2009-11-10T23:01:35Z', 'value': 33}]},
+            self.cli.query('SELECT * FROM memory'))
+
+    @unittest.skip('Not implemented for 0.9')
+    def test_write_points_batch(self):
+        self.cli.create_database('db')
+        self.cli.write_points(
+            points=dummy_point * 3,
+            batch_size=2
+        )
+
+    def test_write_points_with_precision(self):
+        ''' check that points written with an explicit precision have
+        actually that precision used.
+        '''
+        # for that we'll check that - for each precision - the actual 'time'
+        #  value returned by a select has the correct regex format..
+        # n : u'2015-03-20T15:23:36.615654966Z'
+        # u : u'2015-03-20T15:24:10.542554Z'
+        # ms : u'2015-03-20T15:24:50.878Z'
+        # s : u'2015-03-20T15:20:24Z'
+        # m : u'2015-03-20T15:25:00Z'
+        # h : u'2015-03-20T15:00:00Z'
+        base_regex = '\d{4}-\d{2}-\d{2}T\d{2}:'  # YYYY-MM-DD 'T' hh:
+        base_s_regex = base_regex + '\d{2}:\d{2}'  # base_regex + mm:ss
+
+        # As far as we can see the values aren't directly available depending
+        # on the precision used.
+        # The less the precision, the more to wait for the value to be
+        # actually written/available.
+        for idx, (precision, expected_regex, sleep_time) in enumerate((
+            ('n', base_s_regex + '\.\d{1,9}Z', 1),
+            ('u', base_s_regex + '\.\d{1,6}Z', 1),
+            ('ms', base_s_regex + '\.\d{1,3}Z', 1),
+            ('s', base_s_regex + 'Z', 1),
+            ('m', base_regex + '\d{2}:00Z', 60),
+
+            # ('h', base_regex + '00:00Z', ),
+            # that would require a sleep of possibly up to 3600 secs (/ 2 ?)..
+        )):
+            db = 'db'
+            self.cli.create_database(db)
+            before = datetime.datetime.now()
+            self.assertIs(
+                True,
+                self.cli.write_points(
+                    dummy_point_without_timestamp,
+                    time_precision=precision,
+                    database=db))
+
+            # sys.stderr.write('checking presision with %r :
+            # before=%s\n' % (precision, before))
+            after = datetime.datetime.now()
+
+            if sleep_time > 1:
+                sleep_time -= (after if before.min != after.min
+                               else before).second
+
+                start = time.time()
+                timeout = start + sleep_time
+                # sys.stderr.write('should sleep %s ..\n' % sleep_time)
+                while time.time() < timeout:
+                    rsp = self.cli.query('SELECT * FROM cpu_load_short',
+                                         database=db)
+                    if rsp != {'cpu_load_short': []}:
+                        # sys.stderr.write('already ? only slept %s\n' % (
+                        # time.time() - start))
+                        break
+                    time.sleep(1)
+                else:
+                    pass
+                    # sys.stderr.write('ok !\n')
+                sleep_time = 0
+
+            if sleep_time:
+                # sys.stderr.write('sleeping %s..\n' % sleep_time)
+                time.sleep(sleep_time)
+
+            rsp = self.cli.query('SELECT * FROM cpu_load_short', database=db)
+
+            # sys.stderr.write('precision=%s rsp_timestamp = %r\n' % (
+            # precision, rsp['cpu_load_short'][0]['time']))
+            m = re.match(expected_regex, rsp['cpu_load_short'][0]['time'])
+            self.assertIsNotNone(m)
+            self.cli.drop_database(db)
+
+    def test_query(self):
+        self.cli.create_database('db')
+        self.assertIs(True, self.cli.write_points(dummy_point))
+
+    @unittest.skip('Not implemented for 0.9')
+    def test_query_chunked(self):
+        cli = InfluxDBClient(database='db')
+        example_object = {
+            'points': [
+                [1415206250119, 40001, 667],
+                [1415206244555, 30001, 7],
+                [1415206228241, 20001, 788],
+                [1415206212980, 10001, 555],
+                [1415197271586, 10001, 23]
+            ],
+            'name': 'foo',
+            'columns': [
+                'time',
+                'sequence_number',
+                'val'
+            ]
+        }
+        del cli
+        del example_object
+        # TODO
+
+    def test_query_fail(self):
+        with self.assertRaises(InfluxDBClientError) as ctx:
+            self.cli.query('select column_one from foo')
+        self.assertEqual(
+            ('500: {"results":[{"error":"database not found: db"}]}',),
+            ctx.exception.args)
+
+    def test_get_list_series_empty(self):
+        self.cli.create_database('mydb')
+        rsp = self.cli.get_list_series('mydb')
+        self.assertEqual({}, rsp)
+
+    def test_get_list_series_non_empty(self):
+        self.cli.create_database('mydb')
+        self.cli.write_points(dummy_point, database='mydb')
+        rsp = self.cli.get_list_series('mydb')
+        self.assertEqual(
+            {'cpu_load_short': [
+                {'region': 'us-west', 'host': 'server01', '_id': 1}]},
+            rsp
+        )
+
+    def test_default_retention_policy(self):
+        self.cli.create_database('db')
+        rsp = self.cli.get_list_retention_policies('db')
+        self.assertEqual(
+            [
+                {'duration': '0', 'default': True,
+                 'replicaN': 1, 'name': 'default'}],
+            rsp
+        )
+
+    def test_create_retention_policy_default(self):
+        self.cli.create_database('db')
+        rsp = self.cli.create_retention_policy(
+            'somename', '1d', 4, default=True, database='db'
+        )
+        self.assertIsNone(rsp)
+        rsp = self.cli.get_list_retention_policies('db')
+        self.assertEqual(
+            [
+                {'duration': '0', 'default': False,
+                 'replicaN': 1, 'name': 'default'},
+                {'duration': '24h0m0s', 'default': True,
+                 'replicaN': 4, 'name': 'somename'}
+            ],
+            rsp
+        )
+
+    def test_create_retention_policy(self):
+        self.cli.create_database('db')
+        self.cli.create_retention_policy(
+            'somename', '1d', 4, database='db'
+        )
+        rsp = self.cli.get_list_retention_policies('db')
+        self.assertEqual(
+            [
+                {'duration': '0', 'default': True, 'replicaN': 1,
+                 'name': 'default'},
+                {'duration': '24h0m0s', 'default': False, 'replicaN': 4,
+                 'name': 'somename'}
+            ],
+            rsp
+        )
+
+
+@unittest.skipIf(not is_influxdb_bin_ok, "not found any influxd binary")
+class UdpTests(InfluxDbClientTestWithServerInstanceMixin,
+               unittest.TestCase):
+
+    influxdb_template_conf = os.path.join(THIS_DIR,
+                                          'influxdb.udp_conf.template')
+
+    def test_write_points_udp(self):
+
+        cli = InfluxDBClient(
+            'localhost', self.influxd_inst.broker_port,
+            'dont', 'care',
+            database='db',
+            use_udp=True, udp_port=self.influxd_inst.udp_port
+        )
+        cli.create_database('db')
+        cli.write_points(dummy_point)
+
+        # ho boy,
+        # once write_points finishes then the points aren't actually
+        #  already directly available !!
+        # Well, it's normal because we sent by udp (no response !).
+        # So we have to wait some enough time,
+        time.sleep(1)  # 1 sec seems to be a good choice.
+        rsp = cli.query('SELECT * FROM cpu_load_short')
+
+        self.assertEqual(
+            # this is dummy_points :
+            {'cpu_load_short': [
+                {'value': 0.64, 'time': '2009-11-10T23:00:00Z'}]},
+            rsp
+        )

--- a/tests/influxdb/influxdb.conf.template
+++ b/tests/influxdb/influxdb.conf.template
@@ -1,0 +1,99 @@
+# Welcome to the InfluxDB configuration file.
+
+# If hostname (on the OS) doesn't return a name that can be resolved by the other
+# systems in the cluster, you'll have to set the hostname to an IP or something
+# that can be resolved here.
+# hostname = ""
+bind-address = "0.0.0.0"
+
+# Once every 24 hours InfluxDB will report anonymous data to m.influxdb.com
+# The data includes raft id (random 8 bytes), os, arch and version
+# We don't track ip addresses of servers reporting. This is only used
+# to track the number of instances running and the versions, which
+# is very helpful for us.
+# Change this option to true to disable reporting.
+reporting-disabled = false
+
+# Controls settings for initial start-up. Once a node a successfully started,
+# these settings are ignored.
+[initialization]
+join-urls = "" # Comma-delimited URLs, in the form http://host:port, for joining another cluster.
+
+# Control authentication
+# If not set authetication is DISABLED. Be sure to explicitly set this flag to
+# true if you want authentication.
+[authentication]
+enabled = false
+
+# Configure the admin server
+[admin]
+enabled = true
+port = {admin_port}
+
+# Configure the HTTP API endpoint. All time-series data and queries uses this endpoint.
+[api]
+# ssl-port = 8087    # SSL support is enabled if you set a port and cert
+# ssl-cert = "/path/to/cert.pem"
+
+# Configure the Graphite plugins.
+[[graphite]] # 1 or more of these sections may be present.
+enabled = false
+# protocol = "" # Set to "tcp" or "udp"
+# address = "0.0.0.0" # If not set, is actually set to bind-address.
+# port = 2003
+# name-position = "last"
+# name-separator = "-"
+# database = ""  # store graphite data in this database
+
+# Configure the collectd input.
+[collectd]
+enabled = false
+#address = "0.0.0.0" # If not set, is actually set to bind-address.
+#port = 25827
+#database = "collectd_database"
+#typesdb = "types.db"
+
+# Configure UDP listener for series data.
+[udp]
+enabled = false
+#bind-address = "0.0.0.0"
+#port = 4444
+
+# Broker configuration. Brokers are nodes which participate in distributed
+# consensus.
+[broker]
+# Where the Raft logs are stored. The user running InfluxDB will need read/write access.
+dir  = "{broker_raft_dir}"
+port = {broker_port}
+
+# Data node configuration. Data nodes are where the time-series data, in the form of
+# shards, is stored.
+[data]
+  dir = "{broker_node_dir}"
+  port = {broker_port}
+
+  # Auto-create a retention policy when a database is created. Defaults to true.
+  retention-auto-create = true
+
+  # Control whether retention policies are enforced and how long the system waits between
+  # enforcing those policies.
+  retention-check-enabled = true
+  retention-check-period = "10m"
+
+[cluster]
+# Location for cluster state storage. For storing state persistently across restarts.
+dir = "{influxdb_cluster_dir}"
+
+[logging]
+file   = "{influxdb_logfile}" # Leave blank to redirect logs to stderr.
+write-tracing = false # If true, enables detailed logging of the write system.
+raft-tracing = false # If true, enables detailed logging of Raft consensus.
+
+# InfluxDB can store statistics about itself. This is useful for monitoring purposes.
+# This feature is disabled by default, but if enabled, these statistics can be queried
+# as any other data.
+[statistics]
+enabled = false
+database = "internal"         # The database to which the data is written.
+retention-policy = "default"   # The retention policy within the database.
+write-interval = "1m"          # Period between writing the data.

--- a/tests/influxdb/influxdb.udp_conf.template
+++ b/tests/influxdb/influxdb.udp_conf.template
@@ -1,0 +1,99 @@
+# Welcome to the InfluxDB configuration file.
+
+# If hostname (on the OS) doesn't return a name that can be resolved by the other
+# systems in the cluster, you'll have to set the hostname to an IP or something
+# that can be resolved here.
+# hostname = ""
+bind-address = "0.0.0.0"
+
+# Once every 24 hours InfluxDB will report anonymous data to m.influxdb.com
+# The data includes raft id (random 8 bytes), os, arch and version
+# We don't track ip addresses of servers reporting. This is only used
+# to track the number of instances running and the versions, which
+# is very helpful for us.
+# Change this option to true to disable reporting.
+reporting-disabled = false
+
+# Controls settings for initial start-up. Once a node a successfully started,
+# these settings are ignored.
+[initialization]
+join-urls = "" # Comma-delimited URLs, in the form http://host:port, for joining another cluster.
+
+# Control authentication
+# If not set authetication is DISABLED. Be sure to explicitly set this flag to
+# true if you want authentication.
+[authentication]
+enabled = false
+
+# Configure the admin server
+[admin]
+enabled = true
+port = {admin_port}
+
+# Configure the HTTP API endpoint. All time-series data and queries uses this endpoint.
+[api]
+# ssl-port = 8087    # SSL support is enabled if you set a port and cert
+# ssl-cert = "/path/to/cert.pem"
+
+# Configure the Graphite plugins.
+[[graphite]] # 1 or more of these sections may be present.
+enabled = false
+# protocol = "" # Set to "tcp" or "udp"
+# address = "0.0.0.0" # If not set, is actually set to bind-address.
+# port = 2003
+# name-position = "last"
+# name-separator = "-"
+# database = ""  # store graphite data in this database
+
+# Configure the collectd input.
+[collectd]
+enabled = false
+#address = "0.0.0.0" # If not set, is actually set to bind-address.
+#port = 25827
+#database = "collectd_database"
+#typesdb = "types.db"
+
+# Configure UDP listener for series data.
+[udp]
+enabled = true
+#bind-address = "0.0.0.0"
+port = {udp_port}
+
+# Broker configuration. Brokers are nodes which participate in distributed
+# consensus.
+[broker]
+# Where the Raft logs are stored. The user running InfluxDB will need read/write access.
+dir  = "{broker_raft_dir}"
+port = {broker_port}
+
+# Data node configuration. Data nodes are where the time-series data, in the form of
+# shards, is stored.
+[data]
+  dir = "{broker_node_dir}"
+  port = {broker_port}
+
+  # Auto-create a retention policy when a database is created. Defaults to true.
+  retention-auto-create = true
+
+  # Control whether retention policies are enforced and how long the system waits between
+  # enforcing those policies.
+  retention-check-enabled = true
+  retention-check-period = "10m"
+
+[cluster]
+# Location for cluster state storage. For storing state persistently across restarts.
+dir = "{influxdb_cluster_dir}"
+
+[logging]
+file   = "{influxdb_logfile}" # Leave blank to redirect logs to stderr.
+write-tracing = false # If true, enables detailed logging of the write system.
+raft-tracing = false # If true, enables detailed logging of Raft consensus.
+
+# InfluxDB can store statistics about itself. This is useful for monitoring purposes.
+# This feature is disabled by default, but if enabled, these statistics can be queried
+# as any other data.
+[statistics]
+enabled = false
+database = "internal"         # The database to which the data is written.
+retention-policy = "default"   # The retention policy within the database.
+write-interval = "1m"          # Period between writing the data.

--- a/tests/influxdb/misc.py
+++ b/tests/influxdb/misc.py
@@ -1,0 +1,24 @@
+
+
+import socket
+
+
+def get_free_port(ip='127.0.0.1'):
+    sock = socket.socket()
+    try:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind((ip, 0))
+        return sock.getsockname()[1]
+    finally:
+        sock.close()
+
+
+def is_port_open(port, ip='127.0.0.1'):
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        result = sock.connect_ex((ip, port))
+        if not result:
+            sock.shutdown(socket.SHUT_RDWR)
+        return result == 0
+    finally:
+        sock.close()


### PR DESCRIPTION
This PR brings basically 2 things:

+ Add a "client_test_with_server.py" test module, that will upon execution, launch a fresh influxdb server instance in a temporary place.
+ Correct few detected bad things in the client code itself.

any comments ?

client_test_with_server.py could now easily be extended with others (more complex) test cases..