### PR TITLE
Add wheel/twine support

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,3 +4,5 @@ mock
 pandas
 Sphinx==1.2.3
 sphinx_rtd_theme
+wheel
+twine

--- a/release.sh
+++ b/release.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
-python setup.py sdist upload
+python setup.py sdist bdist_wheel
+twine upload dist/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[wheel]
+universal = 1


### PR DESCRIPTION
* installing from a wheel is much faster than from source.
* twice is for securely uploading the package to pypi