### PR TITLE
Fix for get_list_users method in InfluxDBClient

### DIFF
--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -441,7 +441,7 @@ localhost:8086/databasename', timeout=5, udp_port=159)
         """
         Get the list of users
         """
-        return list(self.query("SHOW USERS"))
+        return list(self.query("SHOW USERS")["results"])
 
     def delete_series(self, name, database=None):
         database = database or self._database

--- a/tests/influxdb/client_test.py
+++ b/tests/influxdb/client_test.py
@@ -534,3 +534,34 @@ class TestInfluxDBClient(unittest.TestCase):
 
         with self.assertRaises(requests.exceptions.ConnectionError):
             cli.write_points(self.dummy_points)
+
+    def test_get_list_users(self):
+        example_response = (
+            '{"results":[{"series":[{"columns":["user","admin"],'
+            '"values":[["test",false]]}]}]}'
+        )
+
+        with requests_mock.Mocker() as m:
+            m.register_uri(
+                requests_mock.GET,
+                "http://localhost:8086/query",
+                text=example_response
+            )
+
+            self.assertListEqual(
+                self.cli.get_list_users(),
+                [{'user': 'test', 'admin': False}]
+            )
+
+    def test_get_list_users_empty(self):
+        example_response = (
+            '{"results":[{"series":[{"columns":["user","admin"]}]}]}'
+        )
+        with requests_mock.Mocker() as m:
+            m.register_uri(
+                requests_mock.GET,
+                "http://localhost:8086/query",
+                text=example_response
+            )
+
+            self.assertListEqual(self.cli.get_list_users(), [])

--- a/tests/influxdb/client_test_with_server.py
+++ b/tests/influxdb/client_test_with_server.py
@@ -536,6 +536,19 @@ class CommonTests(ManyTestCasesWithServerMixin,
             rsp
         )
 
+    def test_get_list_users_empty(self):
+        rsp = self.cli.get_list_users()
+        self.assertEqual([], rsp)
+
+    def test_get_list_users_non_empty(self):
+        self.cli.query("CREATE USER test WITH PASSWORD 'test'")
+        rsp = self.cli.get_list_users()
+
+        self.assertEqual(
+            [{'user': 'test', 'admin': False}],
+            rsp
+        )
+
     def test_default_retention_policy(self):
         rsp = self.cli.get_list_retention_policies()
         self.assertEqual(


### PR DESCRIPTION
Hi guys,

Noticed a small bug today with the get_list_users method returning list of lists instead of just a list and this is the proposed fix with included test cases.

Cheers!