### PR TITLE
Add user management operations

### DIFF
--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -443,6 +443,18 @@ localhost:8086/databasename', timeout=5, udp_port=159)
         """
         return list(self.query("SHOW USERS")["results"])
 
+    def create_user(self, username, password):
+        """
+        Create a new user
+
+        :param username: the new username to create
+        :type username: string
+        :param password: the password for the new user
+        :type password: string
+        """
+        text = "CREATE USER {} WITH PASSWORD '{}'".format(username, password)
+        self.query(text)
+
     def delete_series(self, name, database=None):
         database = database or self._database
         self.query('DROP SERIES \"%s\"' % name, database=database)

--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -455,6 +455,16 @@ localhost:8086/databasename', timeout=5, udp_port=159)
         text = "CREATE USER {} WITH PASSWORD '{}'".format(username, password)
         self.query(text)
 
+    def drop_user(self, username):
+        """
+        Drop an user
+
+        :param username: the username to drop
+        :type username: string
+        """
+        text = "DROP USER {}".format(username)
+        self.query(text)
+
     def delete_series(self, name, database=None):
         database = database or self._database
         self.query('DROP SERIES \"%s\"' % name, database=database)

--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -465,6 +465,18 @@ localhost:8086/databasename', timeout=5, udp_port=159)
         text = "DROP USER {}".format(username)
         self.query(text)
 
+    def set_user_password(self, username, password):
+        """
+        Change the password of an existing user
+
+        :param username: the username who's password is being changed
+        :type username: string
+        :param password: the new password for the user
+        :type password: string
+        """
+        text = "SET PASSWORD FOR {} = '{}'".format(username, password)
+        self.query(text)
+
     def delete_series(self, name, database=None):
         database = database or self._database
         self.query('DROP SERIES \"%s\"' % name, database=database)

--- a/tests/influxdb/client_test_with_server.py
+++ b/tests/influxdb/client_test_with_server.py
@@ -323,6 +323,39 @@ class SimpleTests(SingleTestCaseWithServerMixin,
         self.assertIn('{"results":[{"error":"database not found: db',
                       ctx.exception.content)
 
+    def test_create_user(self):
+        self.cli.create_user('test_user', 'secret_password')
+        rsp = list(self.cli.query("SHOW USERS")['results'])
+        self.assertIn({'user': 'test_user', 'admin': False},
+                      rsp)
+
+    def test_create_user_blank_password(self):
+        self.cli.create_user('test_user', '')
+        rsp = list(self.cli.query("SHOW USERS")['results'])
+        self.assertIn({'user': 'test_user', 'admin': False},
+                      rsp)
+
+    def test_create_user_blank_username(self):
+        with self.assertRaises(InfluxDBClientError) as ctx:
+            self.cli.create_user('', 'secret_password')
+        self.assertEqual(400, ctx.exception.code)
+        self.assertIn('{"error":"error parsing query: '
+                      'found WITH, expected identifier',
+                      ctx.exception.content)
+        rsp = list(self.cli.query("SHOW USERS")['results'])
+        self.assertEqual(rsp, [])
+
+    def test_create_user_invalid_username(self):
+        with self.assertRaises(InfluxDBClientError) as ctx:
+            self.cli.create_user('very invalid', 'secret_password')
+        self.assertEqual(400, ctx.exception.code)
+        self.assertIn('{"error":"error parsing query: '
+                      'found invalid, expected WITH',
+                      ctx.exception.content)
+        rsp = list(self.cli.query("SHOW USERS")['results'])
+        self.assertEqual(rsp, [])
+
+
 ############################################################################
 
 

--- a/tests/influxdb/client_test_with_server.py
+++ b/tests/influxdb/client_test_with_server.py
@@ -355,6 +355,27 @@ class SimpleTests(SingleTestCaseWithServerMixin,
         rsp = list(self.cli.query("SHOW USERS")['results'])
         self.assertEqual(rsp, [])
 
+    def test_drop_user(self):
+        self.cli.query("CREATE USER test WITH PASSWORD 'test'")
+        self.cli.drop_user('test')
+        users = list(self.cli.query("SHOW USERS")['results'])
+        self.assertEqual(users, [])
+
+    def test_drop_user_nonexisting(self):
+        with self.assertRaises(InfluxDBClientError) as ctx:
+            self.cli.drop_user('test')
+        self.assertEqual(500, ctx.exception.code)
+        self.assertIn('{"results":[{"error":"user not found"}]}',
+                      ctx.exception.content)
+
+    def test_drop_user_invalid(self):
+        with self.assertRaises(InfluxDBClientError) as ctx:
+            self.cli.drop_user('very invalid')
+        self.assertEqual(400, ctx.exception.code)
+        self.assertIn('{"error":"error parsing query: '
+                      'found invalid, expected',
+                      ctx.exception.content)
+
 
 ############################################################################
 


### PR DESCRIPTION
Hi there,

I added a few methods for user management - create_user, drop_user and set_user_password. Tests are included as well, except for the set_user_password, because I noticed that the actual influxdb query (SET PASSWORD FOR user = 'password') doesn't seem to do much (it appears to me that even after the password is changed one can still query influxdb with the old credentials). When I have more time I'll investigate if that is the case and add tests for that method as well.

Cheers!