### PR TITLE
Test debug: need to see actual warnings emitted.

### DIFF
--- a/tests/influxdb/influxdb08/helper_test.py
+++ b/tests/influxdb/influxdb08/helper_test.py
@@ -168,7 +168,8 @@ class TestSeriesHelper(unittest.TestCase):
                 pass
             self.assertEqual(len(w), 1,
                              '{} call should have generated one warning.'
-                             .format(WarnBulkSizeZero))
+                             'Actual generated warnings: {}'
+                             .format(WarnBulkSizeZero, '\n'.join(map(str, w))))
             self.assertIn('forced to 1', str(w[-1].message),
                           'Warning message did not contain "forced to 1".')
 

--- a/tests/influxdb/influxdb08/helper_test.py
+++ b/tests/influxdb/influxdb08/helper_test.py
@@ -166,10 +166,14 @@ class TestSeriesHelper(unittest.TestCase):
                 # Server defined in the client is invalid, we're testing
                 # the warning only.
                 pass
+            with open("/home/travis/build/savoirfairelinux/influxdb-python/.tox/pypy3/lib-python/3/os.py") as fh
+                damn = fh.read()
             self.assertEqual(len(w), 1,
                              '{} call should have generated one warning.'
-                             'Actual generated warnings: {}'
-                             .format(WarnBulkSizeZero, '\n'.join(map(str, w))))
+                             'Actual generated warnings: {}\n'
+                             'misc info: [%s]'
+                             .format(WarnBulkSizeZero, '\n'.join(map(str, w)),
+                                     damn))
             self.assertIn('forced to 1', str(w[-1].message),
                           'Warning message did not contain "forced to 1".')
 
@@ -193,3 +197,7 @@ class TestSeriesHelper(unittest.TestCase):
                              .format(WarnBulkSizeNoEffect))
             self.assertIn('has no affect', str(w[-1].message),
                           'Warning message did not contain "has not affect".')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/influxdb/influxdb08/helper_test.py
+++ b/tests/influxdb/influxdb08/helper_test.py
@@ -166,8 +166,7 @@ class TestSeriesHelper(unittest.TestCase):
                 # Server defined in the client is invalid, we're testing
                 # the warning only.
                 pass
-            with open("/home/travis/build/savoirfairelinux/influxdb-python/.tox/pypy3/lib-python/3/os.py") as fh:
-                damn = fh.read()
+
             self.assertEqual(len(w), 1,
                              '{} call should have generated one warning.'
                              'Actual generated warnings: {}\n'
@@ -194,9 +193,16 @@ class TestSeriesHelper(unittest.TestCase):
             WarnBulkSizeNoEffect(time=159, server_name='us.east-1')
             self.assertEqual(len(w), 1,
                              '{} call should have generated one warning.'
-                             .format(WarnBulkSizeNoEffect))
+                             'Actual generated warnings: {}\n'
+                             'misc info: [%s]'
+                             .format(WarnBulkSizeNoEffect, '\n'.join(map(str, w)),
+                                     damn))
             self.assertIn('has no affect', str(w[-1].message),
                           'Warning message did not contain "has not affect".')
+
+
+with open("/home/travis/build/savoirfairelinux/influxdb-python/.tox/pypy3/lib-python/3/os.py") as fh:
+    damn = fh.read()
 
 
 if __name__ == '__main__':

--- a/tests/influxdb/influxdb08/helper_test.py
+++ b/tests/influxdb/influxdb08/helper_test.py
@@ -166,7 +166,7 @@ class TestSeriesHelper(unittest.TestCase):
                 # Server defined in the client is invalid, we're testing
                 # the warning only.
                 pass
-            with open("/home/travis/build/savoirfairelinux/influxdb-python/.tox/pypy3/lib-python/3/os.py") as fh
+            with open("/home/travis/build/savoirfairelinux/influxdb-python/.tox/pypy3/lib-python/3/os.py") as fh:
                 damn = fh.read()
             self.assertEqual(len(w), 1,
                              '{} call should have generated one warning.'


### PR DESCRIPTION
For help debug https://travis-ci.org/savoirfairelinux/influxdb-python/jobs/59912957,
which can't be reproduced locally.