### PR TITLE
Add more operations to the client

### DIFF
--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -658,6 +658,22 @@ localhost:8086/databasename', timeout=5, udp_port=159)
                                              username)
         self.query(text)
 
+    def revoke_privilege(self, privilege, database, username):
+        """Revoke a privilege on a database from an user.
+
+        :param privilege: the privilege to revoke, one of 'read', 'write'
+            or 'all'. The string is case-insensitive
+        :type privilege: str
+        :param database: the database to revoke the privilege on
+        :type database: str
+        :param username: the username to revoke the privilege from
+        :type username: str
+        """
+        text = "REVOKE {} ON {} FROM {}".format(privilege,
+                                                database,
+                                                username)
+        self.query(text)
+
     def send_packet(self, packet):
         """Send an UDP packet.
 

--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -642,6 +642,22 @@ localhost:8086/databasename', timeout=5, udp_port=159)
         text = "REVOKE ALL PRIVILEGES FROM {}".format(username)
         self.query(text)
 
+    def grant_privilege(self, privilege, database, username):
+        """Grant a privilege on a database to an user.
+
+        :param privilege: the privilege to grant, one of 'read', 'write'
+            or 'all'. The string is case-insensitive
+        :type privilege: str
+        :param database: the database to grant the privilege on
+        :type database: str
+        :param username: the username to grant the privilege to
+        :type username: str
+        """
+        text = "GRANT {} ON {} TO {}".format(privilege,
+                                             database,
+                                             username)
+        self.query(text)
+
     def send_packet(self, packet):
         """Send an UDP packet.
 

--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -470,6 +470,43 @@ localhost:8086/databasename', timeout=5, udp_port=159)
 
         self.query(query_string)
 
+    def alter_retention_policy(self, name, database=None,
+                               duration=None, replication=None, default=None):
+        """Mofidy an existing retention policy for a database.
+
+        :param name: the name of the retention policy to modify
+        :type name: str
+        :param database: the database for which the retention policy is
+            modified. Defaults to current client's database
+        :type database: str
+        :param duration: the new duration of the existing retention policy.
+            Durations such as 1h, 90m, 12h, 7d, and 4w, are all supported
+            and mean 1 hour, 90 minutes, 12 hours, 7 day, and 4 weeks,
+            respectively. For infinite retention – meaning the data will
+            never be deleted – use 'INF' for duration.
+            The minimum retention period is 1 hour.
+        :type duration: str
+        :param replication: the new replication of the existing
+            retention policy
+        :type replication: str
+        :param default: whether or not to set the modified policy as default
+        :type default: bool
+
+        .. note:: at least one of duration, replication, or default flag
+            should be set. Otherwise the operation will fail.
+        """
+        query_string = (
+            "ALTER RETENTION POLICY {} ON {}"
+        ).format(name, database or self._database)
+        if duration:
+            query_string += " DURATION {}".format(duration)
+        if replication:
+            query_string += " REPLICATION {}".format(replication)
+        if default is True:
+            query_string += " DEFAULT"
+
+        self.query(query_string)
+
     def get_list_retention_policies(self, database=None):
         """Get the list of retention policies for a database.
 

--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -618,6 +618,18 @@ localhost:8086/databasename', timeout=5, udp_port=159)
         database = database or self._database
         self.query('DROP SERIES \"%s\"' % name, database=database)
 
+    def grant_admin_privileges(self, username):
+        """Grant cluster administration privileges to an user.
+
+        :param username: the username to grant privileges to
+        :type username: str
+
+        .. note:: Only a cluster administrator can create/ drop databases
+            and manage users.
+        """
+        text = "GRANT ALL PRIVILEGES TO {}".format(username)
+        self.query(text)
+
     def send_packet(self, packet):
         """Send an UDP packet.
 

--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -630,6 +630,18 @@ localhost:8086/databasename', timeout=5, udp_port=159)
         text = "GRANT ALL PRIVILEGES TO {}".format(username)
         self.query(text)
 
+    def revoke_admin_privileges(self, username):
+        """Revoke cluster administration privileges from an user.
+
+        :param username: the username to revoke privileges from
+        :type username: str
+
+        .. note:: Only a cluster administrator can create/ drop databases
+            and manage users.
+        """
+        text = "REVOKE ALL PRIVILEGES FROM {}".format(username)
+        self.query(text)
+
     def send_packet(self, packet):
         """Send an UDP packet.
 

--- a/tests/influxdb/client_test.py
+++ b/tests/influxdb/client_test.py
@@ -690,6 +690,28 @@ class TestInfluxDBClient(unittest.TestCase):
         with _mocked_session(cli, 'get', 400):
             self.cli.grant_privilege('', 'testdb', 'test')
 
+    def test_revoke_privilege(self):
+        example_response = '{"results":[{}]}'
+
+        with requests_mock.Mocker() as m:
+            m.register_uri(
+                requests_mock.GET,
+                "http://localhost:8086/query",
+                text=example_response
+            )
+            self.cli.revoke_privilege('read', 'testdb', 'test')
+
+            self.assertEqual(
+                m.last_request.qs['q'][0],
+                'revoke read on testdb from test'
+            )
+
+    @raises(Exception)
+    def test_revoke_privilege_invalid(self):
+        cli = InfluxDBClient('host', 8086, 'username', 'password')
+        with _mocked_session(cli, 'get', 400):
+            self.cli.revoke_privilege('', 'testdb', 'test')
+
 
 class FakeClient(InfluxDBClient):
     fail = False

--- a/tests/influxdb/client_test.py
+++ b/tests/influxdb/client_test.py
@@ -624,6 +624,28 @@ class TestInfluxDBClient(unittest.TestCase):
 
             self.assertListEqual(self.cli.get_list_users(), [])
 
+    def test_grant_admin_privileges(self):
+        example_response = '{"results":[{}]}'
+
+        with requests_mock.Mocker() as m:
+            m.register_uri(
+                requests_mock.GET,
+                "http://localhost:8086/query",
+                text=example_response
+            )
+            self.cli.grant_admin_privileges('test')
+
+            self.assertEqual(
+                m.last_request.qs['q'][0],
+                'grant all privileges to test'
+            )
+
+    @raises(Exception)
+    def test_grant_admin_privileges_invalid(self):
+        cli = InfluxDBClient('host', 8086, 'username', 'password')
+        with _mocked_session(cli, 'get', 400):
+            self.cli.grant_admin_privileges('')
+
 
 class FakeClient(InfluxDBClient):
     fail = False

--- a/tests/influxdb/client_test.py
+++ b/tests/influxdb/client_test.py
@@ -668,6 +668,28 @@ class TestInfluxDBClient(unittest.TestCase):
         with _mocked_session(cli, 'get', 400):
             self.cli.revoke_admin_privileges('')
 
+    def test_grant_privilege(self):
+        example_response = '{"results":[{}]}'
+
+        with requests_mock.Mocker() as m:
+            m.register_uri(
+                requests_mock.GET,
+                "http://localhost:8086/query",
+                text=example_response
+            )
+            self.cli.grant_privilege('read', 'testdb', 'test')
+
+            self.assertEqual(
+                m.last_request.qs['q'][0],
+                'grant read on testdb to test'
+            )
+
+    @raises(Exception)
+    def test_grant_privilege_invalid(self):
+        cli = InfluxDBClient('host', 8086, 'username', 'password')
+        with _mocked_session(cli, 'get', 400):
+            self.cli.grant_privilege('', 'testdb', 'test')
+
 
 class FakeClient(InfluxDBClient):
     fail = False

--- a/tests/influxdb/client_test.py
+++ b/tests/influxdb/client_test.py
@@ -646,6 +646,28 @@ class TestInfluxDBClient(unittest.TestCase):
         with _mocked_session(cli, 'get', 400):
             self.cli.grant_admin_privileges('')
 
+    def test_revoke_admin_privileges(self):
+        example_response = '{"results":[{}]}'
+
+        with requests_mock.Mocker() as m:
+            m.register_uri(
+                requests_mock.GET,
+                "http://localhost:8086/query",
+                text=example_response
+            )
+            self.cli.revoke_admin_privileges('test')
+
+            self.assertEqual(
+                m.last_request.qs['q'][0],
+                'revoke all privileges from test'
+            )
+
+    @raises(Exception)
+    def test_revoke_admin_privileges_invalid(self):
+        cli = InfluxDBClient('host', 8086, 'username', 'password')
+        with _mocked_session(cli, 'get', 400):
+            self.cli.revoke_admin_privileges('')
+
 
 class FakeClient(InfluxDBClient):
     fail = False

--- a/tests/influxdb/client_test_with_server.py
+++ b/tests/influxdb/client_test_with_server.py
@@ -407,6 +407,21 @@ class SimpleTests(SingleTestCaseWithServerMixin,
         self.assertIn('{"error":"error parsing query: ',
                       ctx.exception.content)
 
+    def test_grant_privilege(self):
+        self.cli.create_user('test', 'test')
+        self.cli.create_database('testdb')
+        self.cli.grant_privilege('all', 'testdb', 'test')
+        # TODO: when supported by InfluxDB, check if privileges are granted
+
+    def test_grant_privilege_invalid(self):
+        self.cli.create_user('test', 'test')
+        self.cli.create_database('testdb')
+        with self.assertRaises(InfluxDBClientError) as ctx:
+            self.cli.grant_privilege('', 'testdb', 'test')
+        self.assertEqual(400, ctx.exception.code)
+        self.assertIn('{"error":"error parsing query: ',
+                      ctx.exception.content)
+
 
 ############################################################################
 

--- a/tests/influxdb/client_test_with_server.py
+++ b/tests/influxdb/client_test_with_server.py
@@ -376,6 +376,21 @@ class SimpleTests(SingleTestCaseWithServerMixin,
                       'found invalid, expected',
                       ctx.exception.content)
 
+    def test_grant_admin_privileges(self):
+        self.cli.create_user('test', 'test')
+        self.assertEqual([{'user': 'test', 'admin': False}],
+                         self.cli.get_list_users())
+        self.cli.grant_admin_privileges('test')
+        self.assertEqual([{'user': 'test', 'admin': True}],
+                         self.cli.get_list_users())
+
+    def test_grant_admin_privileges_invalid(self):
+        with self.assertRaises(InfluxDBClientError) as ctx:
+            self.cli.grant_admin_privileges('')
+        self.assertEqual(400, ctx.exception.code)
+        self.assertIn('{"error":"error parsing query: ',
+                      ctx.exception.content)
+
 
 ############################################################################
 

--- a/tests/influxdb/client_test_with_server.py
+++ b/tests/influxdb/client_test_with_server.py
@@ -391,6 +391,22 @@ class SimpleTests(SingleTestCaseWithServerMixin,
         self.assertIn('{"error":"error parsing query: ',
                       ctx.exception.content)
 
+    def test_revoke_admin_privileges(self):
+        self.cli.create_user('test', 'test')
+        self.cli.grant_admin_privileges('test')
+        self.assertEqual([{'user': 'test', 'admin': True}],
+                         self.cli.get_list_users())
+        self.cli.revoke_admin_privileges('test')
+        self.assertEqual([{'user': 'test', 'admin': False}],
+                         self.cli.get_list_users())
+
+    def test_revoke_admin_privileges_invalid(self):
+        with self.assertRaises(InfluxDBClientError) as ctx:
+            self.cli.revoke_admin_privileges('')
+        self.assertEqual(400, ctx.exception.code)
+        self.assertIn('{"error":"error parsing query: ',
+                      ctx.exception.content)
+
 
 ############################################################################
 

--- a/tests/influxdb/client_test_with_server.py
+++ b/tests/influxdb/client_test_with_server.py
@@ -422,6 +422,21 @@ class SimpleTests(SingleTestCaseWithServerMixin,
         self.assertIn('{"error":"error parsing query: ',
                       ctx.exception.content)
 
+    def test_revoke_privilege(self):
+        self.cli.create_user('test', 'test')
+        self.cli.create_database('testdb')
+        self.cli.revoke_privilege('all', 'testdb', 'test')
+        # TODO: when supported by InfluxDB, check if privileges are revoked
+
+    def test_revoke_privilege_invalid(self):
+        self.cli.create_user('test', 'test')
+        self.cli.create_database('testdb')
+        with self.assertRaises(InfluxDBClientError) as ctx:
+            self.cli.revoke_privilege('', 'testdb', 'test')
+        self.assertEqual(400, ctx.exception.code)
+        self.assertIn('{"error":"error parsing query: ',
+                      ctx.exception.content)
+
 
 ############################################################################
 


### PR DESCRIPTION
This PR adds an alter_retention_policy method and a few privilege control methods.
It addresses one of the items in the #109 TODO list.

The tests for the read/write privilege control aren't very substantial, but it's expected that InfluxDB will support "show grants" functionality (https://github.com/influxdb/influxdb/issues/2212) in their next point release.

We could test the methods right away, but they will require the authentication to be turned on when the InfluxDB server is started, which is not available as an option in the tests with server at the moment.