### PR TITLE
Remove dsn.lower() from influxdb08.InfluxDBClient.from_DSN()

### DIFF
--- a/influxdb/influxdb08/client.py
+++ b/influxdb/influxdb08/client.py
@@ -134,7 +134,6 @@ class InfluxDBClient(object):
         udp_port parameter (cf. examples).
         :raise ValueError: if the provided DSN has any unexpected value.
         """
-        dsn = dsn.lower()
 
         init_args = {}
         conn_params = urlparse(dsn)

--- a/tests/influxdb/client_test.py
+++ b/tests/influxdb/client_test.py
@@ -29,6 +29,9 @@ import mock
 from influxdb import InfluxDBClient, InfluxDBClusterClient
 from influxdb.client import InfluxDBServerError
 
+DSN_STRING = 'influxdb://uSr:pWd@host:1886/db'
+CLUSTER_DSN_STRING = 'influxdb://uSr:pWd@host1:8086,uSr:pWd@host2:8086/db'
+
 
 def _build_response_object(status_code=200, content=""):
     resp = requests.Response()
@@ -105,20 +108,20 @@ class TestInfluxDBClient(unittest.TestCase):
         self.assertEqual('https://host:8086', cli._baseurl)
 
     def test_dsn(self):
-        cli = InfluxDBClient.from_DSN('influxdb://usr:pwd@host:1886/db')
+        cli = InfluxDBClient.from_DSN(DSN_STRING)
         self.assertEqual('http://host:1886', cli._baseurl)
-        self.assertEqual('usr', cli._username)
-        self.assertEqual('pwd', cli._password)
+        self.assertEqual('uSr', cli._username)
+        self.assertEqual('pWd', cli._password)
         self.assertEqual('db', cli._database)
         self.assertFalse(cli.use_udp)
 
-        cli = InfluxDBClient.from_DSN('udp+influxdb://usr:pwd@host:1886/db')
+        cli = InfluxDBClient.from_DSN('udp+' + DSN_STRING)
         self.assertTrue(cli.use_udp)
 
-        cli = InfluxDBClient.from_DSN('https+influxdb://usr:pwd@host:1886/db')
+        cli = InfluxDBClient.from_DSN('https+' + DSN_STRING)
         self.assertEqual('https://host:1886', cli._baseurl)
 
-        cli = InfluxDBClient.from_DSN('https+influxdb://usr:pwd@host:1886/db',
+        cli = InfluxDBClient.from_DSN('https+' + DSN_STRING,
                                       **{'ssl': False})
         self.assertEqual('http://host:1886', cli._baseurl)
 
@@ -808,33 +811,29 @@ class TestInfluxDBClusterClient(unittest.TestCase):
         self.assertEqual(2, len(cluster.bad_clients))
 
     def test_dsn(self):
-        cli = InfluxDBClusterClient.from_DSN(
-            'influxdb://usr:pwd@host1:8086,usr:pwd@host2:8086/db')
+        cli = InfluxDBClusterClient.from_DSN(CLUSTER_DSN_STRING)
         self.assertEqual(2, len(cli.clients))
         self.assertEqual('http://host1:8086', cli.clients[0]._baseurl)
-        self.assertEqual('usr', cli.clients[0]._username)
-        self.assertEqual('pwd', cli.clients[0]._password)
+        self.assertEqual('uSr', cli.clients[0]._username)
+        self.assertEqual('pWd', cli.clients[0]._password)
         self.assertEqual('db', cli.clients[0]._database)
         self.assertFalse(cli.clients[0].use_udp)
         self.assertEqual('http://host2:8086', cli.clients[1]._baseurl)
-        self.assertEqual('usr', cli.clients[1]._username)
-        self.assertEqual('pwd', cli.clients[1]._password)
+        self.assertEqual('uSr', cli.clients[1]._username)
+        self.assertEqual('pWd', cli.clients[1]._password)
         self.assertEqual('db', cli.clients[1]._database)
         self.assertFalse(cli.clients[1].use_udp)
 
-        cli = InfluxDBClusterClient.from_DSN(
-            'udp+influxdb://usr:pwd@host1:8086,usr:pwd@host2:8086/db')
+        cli = InfluxDBClusterClient.from_DSN('udp+' + CLUSTER_DSN_STRING)
         self.assertTrue(cli.clients[0].use_udp)
         self.assertTrue(cli.clients[1].use_udp)
 
-        cli = InfluxDBClusterClient.from_DSN(
-            'https+influxdb://usr:pwd@host1:8086,usr:pwd@host2:8086/db')
+        cli = InfluxDBClusterClient.from_DSN('https+' + CLUSTER_DSN_STRING)
         self.assertEqual('https://host1:8086', cli.clients[0]._baseurl)
         self.assertEqual('https://host2:8086', cli.clients[1]._baseurl)
 
-        cli = InfluxDBClusterClient.from_DSN(
-            'https+influxdb://usr:pwd@host1:8086,usr:pwd@host2:8086/db',
-            **{'ssl': False})
+        cli = InfluxDBClusterClient.from_DSN('https+' + CLUSTER_DSN_STRING,
+                                             **{'ssl': False})
         self.assertEqual('http://host1:8086', cli.clients[0]._baseurl)
         self.assertEqual('http://host2:8086', cli.clients[1]._baseurl)
 

--- a/tests/influxdb/client_test.py
+++ b/tests/influxdb/client_test.py
@@ -29,9 +29,6 @@ import mock
 from influxdb import InfluxDBClient, InfluxDBClusterClient
 from influxdb.client import InfluxDBServerError
 
-DSN_STRING = 'influxdb://uSr:pWd@host:1886/db'
-CLUSTER_DSN_STRING = 'influxdb://uSr:pWd@host1:8086,uSr:pWd@host2:8086/db'
-
 
 def _build_response_object(status_code=200, content=""):
     resp = requests.Response()
@@ -98,6 +95,8 @@ class TestInfluxDBClient(unittest.TestCase):
             }
         ]
 
+        self.dsn_string = 'influxdb://uSr:pWd@host:1886/db'
+
     def test_scheme(self):
         cli = InfluxDBClient('host', 8086, 'username', 'password', 'database')
         self.assertEqual('http://host:8086', cli._baseurl)
@@ -108,20 +107,20 @@ class TestInfluxDBClient(unittest.TestCase):
         self.assertEqual('https://host:8086', cli._baseurl)
 
     def test_dsn(self):
-        cli = InfluxDBClient.from_DSN(DSN_STRING)
+        cli = InfluxDBClient.from_DSN(self.dsn_string)
         self.assertEqual('http://host:1886', cli._baseurl)
         self.assertEqual('uSr', cli._username)
         self.assertEqual('pWd', cli._password)
         self.assertEqual('db', cli._database)
         self.assertFalse(cli.use_udp)
 
-        cli = InfluxDBClient.from_DSN('udp+' + DSN_STRING)
+        cli = InfluxDBClient.from_DSN('udp+' + self.dsn_string)
         self.assertTrue(cli.use_udp)
 
-        cli = InfluxDBClient.from_DSN('https+' + DSN_STRING)
+        cli = InfluxDBClient.from_DSN('https+' + self.dsn_string)
         self.assertEqual('https://host:1886', cli._baseurl)
 
-        cli = InfluxDBClient.from_DSN('https+' + DSN_STRING,
+        cli = InfluxDBClient.from_DSN('https+' + self.dsn_string,
                                       **{'ssl': False})
         self.assertEqual('http://host:1886', cli._baseurl)
 
@@ -745,6 +744,7 @@ class TestInfluxDBClusterClient(unittest.TestCase):
         warnings.simplefilter('error', FutureWarning)
 
         self.hosts = [('host1', 8086), ('host2', 8086), ('host3', 8086)]
+        self.dsn_string = 'influxdb://uSr:pWd@host1:8086,uSr:pWd@host2:8086/db'
 
     def test_init(self):
         cluster = InfluxDBClusterClient(hosts=self.hosts,
@@ -811,7 +811,7 @@ class TestInfluxDBClusterClient(unittest.TestCase):
         self.assertEqual(2, len(cluster.bad_clients))
 
     def test_dsn(self):
-        cli = InfluxDBClusterClient.from_DSN(CLUSTER_DSN_STRING)
+        cli = InfluxDBClusterClient.from_DSN(self.dsn_string)
         self.assertEqual(2, len(cli.clients))
         self.assertEqual('http://host1:8086', cli.clients[0]._baseurl)
         self.assertEqual('uSr', cli.clients[0]._username)
@@ -824,15 +824,15 @@ class TestInfluxDBClusterClient(unittest.TestCase):
         self.assertEqual('db', cli.clients[1]._database)
         self.assertFalse(cli.clients[1].use_udp)
 
-        cli = InfluxDBClusterClient.from_DSN('udp+' + CLUSTER_DSN_STRING)
+        cli = InfluxDBClusterClient.from_DSN('udp+' + self.dsn_string)
         self.assertTrue(cli.clients[0].use_udp)
         self.assertTrue(cli.clients[1].use_udp)
 
-        cli = InfluxDBClusterClient.from_DSN('https+' + CLUSTER_DSN_STRING)
+        cli = InfluxDBClusterClient.from_DSN('https+' + self.dsn_string)
         self.assertEqual('https://host1:8086', cli.clients[0]._baseurl)
         self.assertEqual('https://host2:8086', cli.clients[1]._baseurl)
 
-        cli = InfluxDBClusterClient.from_DSN('https+' + CLUSTER_DSN_STRING,
+        cli = InfluxDBClusterClient.from_DSN('https+' + self.dsn_string,
                                              **{'ssl': False})
         self.assertEqual('http://host1:8086', cli.clients[0]._baseurl)
         self.assertEqual('http://host2:8086', cli.clients[1]._baseurl)

--- a/tests/influxdb/dataframe_client_test.py
+++ b/tests/influxdb/dataframe_client_test.py
@@ -75,7 +75,7 @@ class TestDataFrameClient(unittest.TestCase):
                            status_code=204)
 
             cli = DataFrameClient(database='db')
-            assert cli.write_points(dataframe, "foo", batch_size=1) is True
+            self.assertTrue(cli.write_points(dataframe, "foo", batch_size=1))
 
     def test_write_points_from_dataframe_with_numeric_column_names(self):
         now = pd.Timestamp('1970-01-01 00:00+00:00')
@@ -266,7 +266,7 @@ class TestDataFrameClient(unittest.TestCase):
         cli = DataFrameClient('host', 8086, 'username', 'password', 'db')
         with _mocked_session(cli, 'GET', 200, {"results": [{}]}):
             result = cli.query('select column_one from foo;')
-            assert result == {}
+            self.assertEqual(result, {})
 
     def test_list_series(self):
         response = {

--- a/tests/influxdb/influxdb08/client_test.py
+++ b/tests/influxdb/influxdb08/client_test.py
@@ -27,6 +27,8 @@ else:
     def u(x):
         return x
 
+DSN_STRING = 'influxdb://uSr:pWd@host:1886/db'
+
 
 def _build_response_object(status_code=200, content=""):
     resp = requests.Response()
@@ -91,47 +93,47 @@ class TestInfluxDBClient(unittest.TestCase):
 
     def test_scheme(self):
         cli = InfluxDBClient('host', 8086, 'username', 'password', 'database')
-        assert cli._baseurl == 'http://host:8086'
+        self.assertEqual(cli._baseurl, 'http://host:8086')
 
         cli = InfluxDBClient(
             'host', 8086, 'username', 'password', 'database', ssl=True
         )
-        assert cli._baseurl == 'https://host:8086'
+        self.assertEqual(cli._baseurl, 'https://host:8086')
 
     def test_dsn(self):
-        cli = InfluxDBClient.from_DSN('influxdb://usr:pwd@host:1886/db')
-        assert cli._baseurl == 'http://host:1886'
-        assert cli._username == 'usr'
-        assert cli._password == 'pwd'
-        assert cli._database == 'db'
-        assert cli.use_udp is False
+        cli = InfluxDBClient.from_DSN(DSN_STRING)
+        self.assertEqual('http://host:1886', cli._baseurl)
+        self.assertEqual('uSr', cli._username)
+        self.assertEqual('pWd', cli._password)
+        self.assertEqual('db', cli._database)
+        self.assertFalse(cli.use_udp)
 
-        cli = InfluxDBClient.from_DSN('udp+influxdb://usr:pwd@host:1886/db')
-        assert cli.use_udp is True
+        cli = InfluxDBClient.from_DSN('udp+' + DSN_STRING)
+        self.assertTrue(cli.use_udp)
 
-        cli = InfluxDBClient.from_DSN('https+influxdb://usr:pwd@host:1886/db')
-        assert cli._baseurl == 'https://host:1886'
+        cli = InfluxDBClient.from_DSN('https+' + DSN_STRING)
+        self.assertEqual('https://host:1886', cli._baseurl)
 
-        cli = InfluxDBClient.from_DSN('https+influxdb://usr:pwd@host:1886/db',
+        cli = InfluxDBClient.from_DSN('https+' + DSN_STRING,
                                       **{'ssl': False})
-        assert cli._baseurl == 'http://host:1886'
+        self.assertEqual('http://host:1886', cli._baseurl)
 
     def test_switch_database(self):
         cli = InfluxDBClient('host', 8086, 'username', 'password', 'database')
         cli.switch_database('another_database')
-        assert cli._database == 'another_database'
+        self.assertEqual(cli._database, 'another_database')
 
     @raises(FutureWarning)
     def test_switch_db_deprecated(self):
         cli = InfluxDBClient('host', 8086, 'username', 'password', 'database')
         cli.switch_db('another_database')
-        assert cli._database == 'another_database'
+        self.assertEqual(cli._database, 'another_database')
 
     def test_switch_user(self):
         cli = InfluxDBClient('host', 8086, 'username', 'password', 'database')
         cli.switch_user('another_username', 'another_password')
-        assert cli._username == 'another_username'
-        assert cli._password == 'another_password'
+        self.assertEqual(cli._username, 'another_username')
+        self.assertEqual(cli._password, 'another_password')
 
     def test_write(self):
         with requests_mock.Mocker() as m:
@@ -250,8 +252,8 @@ class TestInfluxDBClient(unittest.TestCase):
 
         received_data, addr = s.recvfrom(1024)
 
-        assert self.dummy_points == \
-            json.loads(received_data.decode(), strict=True)
+        self.assertEqual(self.dummy_points,
+                         json.loads(received_data.decode(), strict=True))
 
     def test_write_bad_precision_udp(self):
         cli = InfluxDBClient(
@@ -277,7 +279,7 @@ class TestInfluxDBClient(unittest.TestCase):
     def test_write_points_with_precision(self):
         with _mocked_session('post', 200, self.dummy_points):
             cli = InfluxDBClient('host', 8086, 'username', 'password', 'db')
-            assert cli.write_points(self.dummy_points) is True
+            self.assertTrue(cli.write_points(self.dummy_points))
 
     def test_write_points_bad_precision(self):
         cli = InfluxDBClient()
@@ -299,13 +301,14 @@ class TestInfluxDBClient(unittest.TestCase):
     def test_delete_points(self):
         with _mocked_session('delete', 204) as mocked:
             cli = InfluxDBClient('host', 8086, 'username', 'password', 'db')
-            assert cli.delete_points("foo") is True
+            self.assertTrue(cli.delete_points("foo"))
 
-            assert len(mocked.call_args_list) == 1
+            self.assertEqual(len(mocked.call_args_list), 1)
             args, kwds = mocked.call_args_list[0]
 
-            assert kwds['params'] == {'u': 'username', 'p': 'password'}
-            assert kwds['url'] == 'http://host:8086/db/db/series/foo'
+            self.assertEqual(kwds['params'],
+                             {'u': 'username', 'p': 'password'})
+            self.assertEqual(kwds['url'], 'http://host:8086/db/db/series/foo')
 
     @raises(Exception)
     def test_delete_points_with_wrong_name(self):
@@ -342,7 +345,7 @@ class TestInfluxDBClient(unittest.TestCase):
         with _mocked_session('get', 200, data):
             cli = InfluxDBClient('host', 8086, 'username', 'password', 'db')
             result = cli.query('select column_one from foo;')
-            assert len(result[0]['points']) == 4
+            self.assertEqual(len(result[0]['points']), 4)
 
     def test_query_chunked(self):
         cli = InfluxDBClient(database='db')
@@ -422,7 +425,7 @@ class TestInfluxDBClient(unittest.TestCase):
     def test_create_database(self):
         with _mocked_session('post', 201, {"name": "new_db"}):
             cli = InfluxDBClient('host', 8086, 'username', 'password', 'db')
-            assert cli.create_database('new_db') is True
+            self.assertTrue(cli.create_database('new_db'))
 
     @raises(Exception)
     def test_create_database_fails(self):
@@ -433,7 +436,7 @@ class TestInfluxDBClient(unittest.TestCase):
     def test_delete_database(self):
         with _mocked_session('delete', 204):
             cli = InfluxDBClient('host', 8086, 'username', 'password', 'db')
-            assert cli.delete_database('old_db') is True
+            self.assertTrue(cli.delete_database('old_db'))
 
     @raises(Exception)
     def test_delete_database_fails(self):
@@ -447,8 +450,8 @@ class TestInfluxDBClient(unittest.TestCase):
         ]
         with _mocked_session('get', 200, data):
             cli = InfluxDBClient('host', 8086, 'username', 'password')
-            assert len(cli.get_list_database()) == 1
-            assert cli.get_list_database()[0]['name'] == 'a_db'
+            self.assertEqual(len(cli.get_list_database()), 1)
+            self.assertEqual(cli.get_list_database()[0]['name'], 'a_db')
 
     @raises(Exception)
     def test_get_list_database_fails(self):
@@ -463,8 +466,8 @@ class TestInfluxDBClient(unittest.TestCase):
         ]
         with _mocked_session('get', 200, data):
             cli = InfluxDBClient('host', 8086, 'username', 'password')
-            assert len(cli.get_database_list()) == 1
-            assert cli.get_database_list()[0]['name'] == 'a_db'
+            self.assertEqual(len(cli.get_database_list()), 1)
+            self.assertEqual(cli.get_database_list()[0]['name'], 'a_db')
 
     def test_delete_series(self):
         with _mocked_session('delete', 204):

--- a/tests/influxdb/influxdb08/client_test.py
+++ b/tests/influxdb/influxdb08/client_test.py
@@ -27,8 +27,6 @@ else:
     def u(x):
         return x
 
-DSN_STRING = 'influxdb://uSr:pWd@host:1886/db'
-
 
 def _build_response_object(status_code=200, content=""):
     resp = requests.Response()
@@ -91,6 +89,8 @@ class TestInfluxDBClient(unittest.TestCase):
             }
         ]
 
+        self.dsn_string = 'influxdb://uSr:pWd@host:1886/db'
+
     def test_scheme(self):
         cli = InfluxDBClient('host', 8086, 'username', 'password', 'database')
         self.assertEqual(cli._baseurl, 'http://host:8086')
@@ -101,20 +101,20 @@ class TestInfluxDBClient(unittest.TestCase):
         self.assertEqual(cli._baseurl, 'https://host:8086')
 
     def test_dsn(self):
-        cli = InfluxDBClient.from_DSN(DSN_STRING)
+        cli = InfluxDBClient.from_DSN(self.dsn_string)
         self.assertEqual('http://host:1886', cli._baseurl)
         self.assertEqual('uSr', cli._username)
         self.assertEqual('pWd', cli._password)
         self.assertEqual('db', cli._database)
         self.assertFalse(cli.use_udp)
 
-        cli = InfluxDBClient.from_DSN('udp+' + DSN_STRING)
+        cli = InfluxDBClient.from_DSN('udp+' + self.dsn_string)
         self.assertTrue(cli.use_udp)
 
-        cli = InfluxDBClient.from_DSN('https+' + DSN_STRING)
+        cli = InfluxDBClient.from_DSN('https+' + self.dsn_string)
         self.assertEqual('https://host:1886', cli._baseurl)
 
-        cli = InfluxDBClient.from_DSN('https+' + DSN_STRING,
+        cli = InfluxDBClient.from_DSN('https+' + self.dsn_string,
                                       **{'ssl': False})
         self.assertEqual('http://host:1886', cli._baseurl)
 

--- a/tests/influxdb/influxdb08/dataframe_client_test.py
+++ b/tests/influxdb/influxdb08/dataframe_client_test.py
@@ -63,8 +63,7 @@ class TestDataFrameClient(unittest.TestCase):
                            "http://localhost:8086/db/db/series")
 
             cli = DataFrameClient(database='db')
-            assert cli.write_points({"foo": dataframe},
-                                    batch_size=1) is True
+            self.assertTrue(cli.write_points({"foo": dataframe}, batch_size=1))
 
     def test_write_points_from_dataframe_with_numeric_column_names(self):
         now = pd.Timestamp('1970-01-01 00:00+00:00')
@@ -239,7 +238,7 @@ class TestDataFrameClient(unittest.TestCase):
             cli = DataFrameClient('host', 8086, 'username', 'password', 'db')
             result = cli.query("""select mean(value), min(value), max(value),
                 stddev(value) from series1, series2, series3""")
-            assert dataframes.keys() == result.keys()
+            self.assertEqual(dataframes.keys(), result.keys())
             for key in dataframes.keys():
                 assert_frame_equal(dataframes[key], result[key])
 
@@ -247,7 +246,7 @@ class TestDataFrameClient(unittest.TestCase):
         with _mocked_session('get', 200, []):
             cli = DataFrameClient('host', 8086, 'username', 'password', 'db')
             result = cli.query('select column_one from foo;')
-            assert result == []
+            self.assertEqual(result, [])
 
     def test_list_series(self):
         response = [
@@ -260,7 +259,7 @@ class TestDataFrameClient(unittest.TestCase):
         with _mocked_session('get', 200, response):
             cli = DataFrameClient('host', 8086, 'username', 'password', 'db')
             series_list = cli.get_list_series()
-            assert series_list == ['seriesA', 'seriesB']
+            self.assertEqual(series_list, ['seriesA', 'seriesB'])
 
     def test_datetime_to_epoch(self):
         timestamp = pd.Timestamp('2013-01-01 00:00:00.000+00:00')


### PR DESCRIPTION
InfluxDBClient.from_DSN() now behaves correctly and allows (for example) case-sensitive password.