### PR TITLE
Refactored ResultSet

### DIFF
--- a/docs/source/resultset.rst
+++ b/docs/source/resultset.rst
@@ -7,33 +7,39 @@ Query response object: ResultSet
 
 Using the ``InfluxDBClient.query()`` function will return a ``ResultSet`` Object.
 
-A ResultSet behaves like a dict. Its keys are series and values are points. However, it is a little bit smarter than a regular dict. Its ``__getitem__`` method can be used to query the ResultSet in several ways.
+A ResultSet can be browsed in several ways. Its ``get_points`` method can be used to retrieve points generators that filter either by measurement, tags, or both.
 
-Filtering by serie name
------------------------
+Getting all points
+------------------
 
-Using ``rs['cpu']`` will return a generator for all the points that are in a serie named ``cpu``, no matter the tags.
+Using ``rs.get_points()`` will return a generator for all the points in the ResultSet.
+
+
+Filtering by measurement
+------------------------
+
+Using ``rs.get_points('cpu')`` will return a generator for all the points that are in a serie with measurement name ``cpu``, no matter the tags.
 ::
 
     rs = cli.query("SELECT * from cpu")
-    cpu_points = list(rs['cpu'])
+    cpu_points = list(rs.get_points(measurement='cpu')])
 
 Filtering by tags
 -----------------
 
-Using ``rs[{'host_name': 'influxdb.com'}]`` will return a generator for all the points that are tagged with the specified tags, no matter the serie name.
+Using ``rs.get_points(tags={'host_name': 'influxdb.com'})`` will return a generator for all the points that are tagged with the specified tags, no matter the measurement name.
 ::
 
     rs = cli.query("SELECT * from cpu")
     cpu_influxdb_com_points = list(rs[{"host_name": "influxdb.com"}])
 
-Filtering by serie name and tags
---------------------------------
+Filtering by measurement and tags
+---------------------------------
 
-Using a tuple with a serie name and a dict will return a generator for all the points that are in a serie with the given name AND whose tags match the given tags.
+Using measurement name and tags will return a generator for all the points that are in a serie with the specified measurement name AND whose tags match the given tags.
 ::
 
     rs = cli.query("SELECT * from cpu")
-    points = list(rs[('cpu', {'host_name': 'influxdb.com'})])
+    points = list(rs.get_points(measurement='cpu', tags={'host_name': 'influxdb.com'}))
 
 See the :ref:`api-documentation` page for more information.

--- a/influxdb/exceptions.py
+++ b/influxdb/exceptions.py
@@ -1,0 +1,22 @@
+class InfluxDBClientError(Exception):
+    """Raised when an error occurs in the request."""
+    def __init__(self, content, code=None):
+        if isinstance(content, type(b'')):
+            content = content.decode('UTF-8', errors='replace')
+
+        if code is not None:
+            message = "%s: %s" % (code, content)
+        else:
+            message = content
+
+        super(InfluxDBClientError, self).__init__(
+            message
+        )
+        self.content = content
+        self.code = code
+
+
+class InfluxDBServerError(Exception):
+    """Raised when a server error occurs."""
+    def __init__(self, content):
+        super(InfluxDBServerError, self).__init__(content)

--- a/influxdb/resultset.py
+++ b/influxdb/resultset.py
@@ -1,13 +1,18 @@
 # -*- coding: utf-8 -*-
 
+from influxdb.exceptions import InfluxDBClientError
+
 _sentinel = object()
 
 
 class ResultSet(object):
-    """A wrapper around series results """
+    """A wrapper around a single InfluxDB query result"""
 
     def __init__(self, series):
         self._raw = series
+
+        if 'error' in self.raw:
+            raise InfluxDBClientError(self.raw['error'])
 
     @property
     def raw(self):
@@ -46,8 +51,14 @@ class ResultSet(object):
             name = key
             tags = None
 
-        if not isinstance(name, (bytes, type(b''.decode()), type(None))):
-            raise TypeError('serie_name must be an str or None')
+        return self.get_points(name, tags)
+
+    def get_points(self, measurement=None, tags=None):
+
+        # Raise error if measurement is not str or bytes
+        if not isinstance(measurement,
+                          (bytes, type(b''.decode()), type(None))):
+            raise TypeError('measurement must be an str or None')
 
         for serie in self._get_series():
             serie_name = serie.get('measurement', serie.get('name', 'results'))
@@ -55,14 +66,14 @@ class ResultSet(object):
                 # this is a "system" query or a query which
                 # doesn't return a name attribute.
                 # like 'show retention policies' ..
-                if key is None:
+                if tags is None:
                     for point in serie['values']:
                         yield self.point_from_cols_vals(
                             serie['columns'],
                             point
                         )
 
-            elif name in (None, serie_name):
+            elif measurement in (None, serie_name):
                 # by default if no tags was provided then
                 # we will matches every returned serie
                 serie_tags = serie.get('tags', {})
@@ -101,13 +112,7 @@ class ResultSet(object):
 
     def _get_series(self):
         """Returns all series"""
-        series = []
-        try:
-            for result in self.raw['results']:
-                series.extend(result['series'])
-        except KeyError:
-            pass
-        return series
+        return self.raw.get('series', [])
 
     def __len__(self):
         return len(self.keys())

--- a/tests/influxdb/client_test.py
+++ b/tests/influxdb/client_test.py
@@ -337,7 +337,7 @@ class TestInfluxDBClient(unittest.TestCase):
             rs = self.cli.query('select * from foo')
 
             self.assertListEqual(
-                list(rs['cpu_load_short']),
+                list(rs[0].get_points()),
                 [{'value': 0.64, 'time': '2009-11-10T23:00:00Z'}]
             )
 

--- a/tests/influxdb/client_test_with_server.py
+++ b/tests/influxdb/client_test_with_server.py
@@ -29,7 +29,7 @@ import warnings
 warnings.simplefilter('error', FutureWarning)
 
 from influxdb import InfluxDBClient
-from influxdb.client import InfluxDBClientError
+from influxdb.exceptions import InfluxDBClientError
 
 from tests.influxdb.misc import get_free_port, is_port_open
 from tests import skipIfPYpy, using_pypy
@@ -337,13 +337,11 @@ class SimpleTests(SingleTestCaseWithServerMixin,
             [{'name': 'new_db_1'}, {'name': 'new_db_2'}]
         )
 
-    @unittest.skip("Broken as of 0.9.0-rc30")
     def test_create_database_fails(self):
         self.assertIsNone(self.cli.create_database('new_db'))
         with self.assertRaises(InfluxDBClientError) as ctx:
             self.cli.create_database('new_db')
-        self.assertEqual(500, ctx.exception.code)
-        self.assertEqual('{"results":[{"error":"database exists"}]}',
+        self.assertEqual('database already exists',
                          ctx.exception.content)
 
     def test_get_list_series_empty(self):
@@ -360,20 +358,16 @@ class SimpleTests(SingleTestCaseWithServerMixin,
         self.assertIsNone(self.cli.drop_database('new_db_1'))
         self.assertEqual([{'name': 'new_db_2'}], self.cli.get_list_database())
 
-    @unittest.skip("Broken as of 0.9.0-rc30")
     def test_drop_database_fails(self):
         with self.assertRaises(InfluxDBClientError) as ctx:
             self.cli.drop_database('db')
-        self.assertEqual(500, ctx.exception.code)
-        self.assertIn('{"results":[{"error":"database not found: db',
+        self.assertIn('database not found: db',
                       ctx.exception.content)
 
-    @unittest.skip("Broken as of 0.9.0-rc30")
     def test_query_fail(self):
         with self.assertRaises(InfluxDBClientError) as ctx:
             self.cli.query('select column_one from foo')
-        self.assertEqual(500, ctx.exception.code)
-        self.assertIn('{"results":[{"error":"database not found: db',
+        self.assertIn('database not found: db',
                       ctx.exception.content)
 
     def test_create_user(self):
@@ -387,6 +381,19 @@ class SimpleTests(SingleTestCaseWithServerMixin,
         rsp = list(self.cli.query("SHOW USERS")['results'])
         self.assertIn({'user': 'test_user', 'admin': False},
                       rsp)
+
+    def test_get_list_users_empty(self):
+        rsp = self.cli.get_list_users()
+        self.assertEqual([], rsp)
+
+    def test_get_list_users(self):
+        self.cli.query("CREATE USER test WITH PASSWORD 'test'")
+        rsp = self.cli.get_list_users()
+
+        self.assertEqual(
+            [{'user': 'test', 'admin': False}],
+            rsp
+        )
 
     def test_create_user_blank_username(self):
         with self.assertRaises(InfluxDBClientError) as ctx:
@@ -414,12 +421,10 @@ class SimpleTests(SingleTestCaseWithServerMixin,
         users = list(self.cli.query("SHOW USERS")['results'])
         self.assertEqual(users, [])
 
-    @unittest.skip("Broken as of 0.9.0-rc30")
     def test_drop_user_nonexisting(self):
         with self.assertRaises(InfluxDBClientError) as ctx:
             self.cli.drop_user('test')
-        self.assertEqual(500, ctx.exception.code)
-        self.assertIn('{"results":[{"error":"user not found"}]}',
+        self.assertIn('user not found',
                       ctx.exception.content)
 
     def test_drop_user_invalid(self):
@@ -550,7 +555,7 @@ class CommonTests(ManyTestCasesWithServerMixin,
             [[{'value': 0.64, 'time': '2009-11-10T23:00:00Z'}]]
         )
 
-        rsp2 = list(rsp['cpu_load_short'])
+        rsp2 = list(rsp.get_points())
         self.assertEqual(len(rsp2), 1)
         pt = rsp2[0]
 
@@ -634,10 +639,10 @@ class CommonTests(ManyTestCasesWithServerMixin,
                               batch_size=2)
         time.sleep(5)
         net_in = self.cli.query("SELECT value FROM network "
-                                "WHERE direction='in'").raw['results'][0]
+                                "WHERE direction='in'").raw
         net_out = self.cli.query("SELECT value FROM network "
-                                 "WHERE direction='out'").raw['results'][0]
-        cpu = self.cli.query("SELECT value FROM cpu_usage").raw['results'][0]
+                                 "WHERE direction='out'").raw
+        cpu = self.cli.query("SELECT value FROM cpu_usage").raw
         self.assertIn(123, net_in['series'][0]['values'][0])
         self.assertIn(12, net_out['series'][0]['values'][0])
         self.assertIn(12.34, cpu['series'][0]['values'][0])
@@ -795,19 +800,6 @@ class CommonTests(ManyTestCasesWithServerMixin,
             [[1, 'server01', 'us-west']],
             columns=['_id', 'host', 'region'])
         assert_frame_equal(rsp['cpu_load_short'], expected)
-
-    def test_get_list_users_empty(self):
-        rsp = self.cli.get_list_users()
-        self.assertEqual([], rsp)
-
-    def test_get_list_users_non_empty(self):
-        self.cli.query("CREATE USER test WITH PASSWORD 'test'")
-        rsp = self.cli.get_list_users()
-
-        self.assertEqual(
-            [{'user': 'test', 'admin': False}],
-            rsp
-        )
 
     def test_default_retention_policy(self):
         rsp = self.cli.get_list_retention_policies()

--- a/tests/influxdb/resultset_test.py
+++ b/tests/influxdb/resultset_test.py
@@ -2,6 +2,7 @@
 
 import unittest
 
+from influxdb.exceptions import InfluxDBClientError
 from influxdb.resultset import ResultSet
 
 
@@ -33,24 +34,33 @@ class TestResultSet(unittest.TestCase):
                              ]}]}
             ]
         }
-        self.rs = ResultSet(self.query_response)
+        self.rs = ResultSet(self.query_response['results'][0])
 
     def test_filter_by_name(self):
-        self.assertEqual(
-            list(self.rs['cpu_load_short']),
-            [
-                {'value': 0.64, 'time': '2015-01-29T21:51:28.968422294Z'},
-                {'value': 0.65, 'time': '2015-01-29T21:51:28.968422294Z'}
-            ]
-        )
+        expected = [
+            {'value': 0.64, 'time': '2015-01-29T21:51:28.968422294Z'},
+            {'value': 0.65, 'time': '2015-01-29T21:51:28.968422294Z'}
+        ]
+
+        self.assertEqual(expected, list(self.rs['cpu_load_short']))
+        self.assertEqual(expected,
+                         list(self.rs.get_points(
+                             measurement='cpu_load_short')))
 
     def test_filter_by_tags(self):
+        expected = [
+            {'time': '2015-01-29T21:51:28.968422294Z', 'value': 0.64},
+            {'time': '2015-01-29T21:51:28.968422294Z', 'value': 0.66}
+        ]
+
         self.assertEqual(
-            list(self.rs[{"host": "server01"}]),
-            [
-                {'time': '2015-01-29T21:51:28.968422294Z', 'value': 0.64},
-                {'time': '2015-01-29T21:51:28.968422294Z', 'value': 0.66}
-            ]
+            expected,
+            list(self.rs[{"host": "server01"}])
+        )
+
+        self.assertEqual(
+            expected,
+            list(self.rs.get_points(tags={'host': 'server01'}))
         )
 
     def test_filter_by_name_and_tags(self):
@@ -120,15 +130,12 @@ class TestResultSet(unittest.TestCase):
 
     def test_system_query(self):
         rs = ResultSet(
-            {'results': [
-                {'series': [
-                    {'values': [['another', '48h0m0s', 3, False],
-                                ['default', '0', 1, False],
-                                ['somename', '24h0m0s', 4, True]],
-                     'columns': ['name', 'duration',
-                                 'replicaN', 'default']}]}
-            ]
-            }
+            {'series': [
+                {'values': [['another', '48h0m0s', 3, False],
+                            ['default', '0', 1, False],
+                            ['somename', '24h0m0s', 4, True]],
+                 'columns': ['name', 'duration',
+                             'replicaN', 'default']}]}
         )
 
         self.assertEqual(
@@ -147,3 +154,10 @@ class TestResultSet(unittest.TestCase):
                  'name': 'somename'}
             ]
         )
+
+    def test_resultset_error(self):
+        with self.assertRaises(InfluxDBClientError):
+            ResultSet({
+                "series": [],
+                "error": "Big error, many problems."
+            })


### PR DESCRIPTION
Improvements on the ResultSet API to make it more intuitive.

* Replaced ``__getitem__`` by ``get_points()``
* Added warnings on ``__getitem__``
* Raise errors when they are present in ResultSets
* closes #192 - Return several ResultSets when apropriate
* Re-enable tests that were broken due to the fact that HTTP errors are no longer returned