### PR TITLE
Allows python `NaN` values to be written as `null` in the JSON data

### DIFF
--- a/influxdb/influxdb08/client.py
+++ b/influxdb/influxdb08/client.py
@@ -7,6 +7,7 @@ import socket
 import requests
 import requests.exceptions
 import warnings
+import simplejson
 from sys import version_info
 
 from influxdb import chunked_json
@@ -226,7 +227,7 @@ class InfluxDBClient(object):
         params.update(auth)
 
         if data is not None and not isinstance(data, str):
-            data = json.dumps(data)
+            data = simplejson.dumps(data, ignore_nan=True)
 
         # Try to send the request a maximum of three times. (see #103)
         # TODO (aviau): Make this configurable.


### PR DESCRIPTION
JSON dump modified to allows python `NaN` values to be written as `null` in the JSON data

see https://github.com/influxdb/influxdb-python/issues/195

Adds a new dependency to module   `simplejson` but the same effect is difficult to achieve with base module `json`
see http://stackoverflow.com/questions/28639953/python-nan-json-encoder