### PR TITLE
Fix write_points_batch test for python3 and update queries in compliance with InfluxDB v0.9.1

### DIFF
--- a/tests/influxdb/client_test.py
+++ b/tests/influxdb/client_test.py
@@ -223,7 +223,8 @@ class TestInfluxDBClient(unittest.TestCase):
                                    "region": "us-west"},
                              batch_size=2)
         self.assertEqual(m.call_count, 2)
-        self.assertEqual(expected_last_body, m.last_request.body)
+        self.assertEqual(expected_last_body,
+                         m.last_request.body.decode('utf-8'))
 
     def test_write_points_udp(self):
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)

--- a/tests/influxdb/client_test.py
+++ b/tests/influxdb/client_test.py
@@ -615,28 +615,6 @@ class TestInfluxDBClient(unittest.TestCase):
 
             self.assertListEqual(self.cli.get_list_users(), [])
 
-    def test_grant_admin_privileges(self):
-        example_response = '{"results":[{}]}'
-
-        with requests_mock.Mocker() as m:
-            m.register_uri(
-                requests_mock.GET,
-                "http://localhost:8086/query",
-                text=example_response
-            )
-            self.cli.grant_admin_privileges('test')
-
-            self.assertEqual(
-                m.last_request.qs['q'][0],
-                'grant all privileges to test'
-            )
-
-    @raises(Exception)
-    def test_grant_admin_privileges_invalid(self):
-        cli = InfluxDBClient('host', 8086, 'username', 'password')
-        with _mocked_session(cli, 'get', 400):
-            self.cli.grant_admin_privileges('')
-
     def test_revoke_admin_privileges(self):
         example_response = '{"results":[{}]}'
 


### PR DESCRIPTION
Fixes the last failing test for #211 :).
Updates queries and tests for InfluxDB v0.9.1.