### PR TITLE
change line protocol to reflect changes in newest influx (now with tests!)

### DIFF
--- a/influxdb/line_protocol.py
+++ b/influxdb/line_protocol.py
@@ -116,6 +116,8 @@ def make_lines(data, precision=None):
             key = _escape_tag(field_key)
             value = _escape_value(point['fields'][field_key])
             if key != '' and value != '':
+                if isinstance(value, int):
+                    value = str(value) + 'i'
                 field_values.append("{key}={value}".format(
                     key=key,
                     value=value

--- a/influxdb/line_protocol.py
+++ b/influxdb/line_protocol.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from numbers import Integral
 
 from dateutil.parser import parse
-from six import binary_type, text_type
+from six import binary_type, text_type, integer_types
 
 
 def _convert_timestamp(timestamp, precision=None):
@@ -59,7 +59,7 @@ def _escape_value(value):
                 "\n", "\\n"
             )
         )
-    if isinstance(value, int):
+    elif isinstance(value, integer_types):
         return str(value) + 'i'
     else:
         return str(value)

--- a/influxdb/line_protocol.py
+++ b/influxdb/line_protocol.py
@@ -59,6 +59,8 @@ def _escape_value(value):
                 "\n", "\\n"
             )
         )
+    if isinstance(value, int):
+        return str(value) + 'i'
     else:
         return str(value)
 
@@ -116,8 +118,6 @@ def make_lines(data, precision=None):
             key = _escape_tag(field_key)
             value = _escape_value(point['fields'][field_key])
             if key != '' and value != '':
-                if isinstance(value, int):
-                    value = str(value) + 'i'
                 field_values.append("{key}={value}".format(
                     key=key,
                     value=value

--- a/influxdb/tests/dataframe_client_test.py
+++ b/influxdb/tests/dataframe_client_test.py
@@ -32,8 +32,8 @@ class TestDataFrameClient(unittest.TestCase):
                                  columns=["column_one", "column_two",
                                           "column_three"])
         expected = (
-            b"foo column_one=\"1\",column_three=1.0,column_two=1 0\n"
-            b"foo column_one=\"2\",column_three=2.0,column_two=2 "
+            b"foo column_one=\"1\",column_three=1.0,column_two=1i 0\n"
+            b"foo column_one=\"2\",column_three=2.0,column_two=2i "
             b"3600000000000\n"
         )
 
@@ -71,8 +71,8 @@ class TestDataFrameClient(unittest.TestCase):
                                  index=[now, now + timedelta(hours=1)])
 
         expected = (
-            b'foo,hello=there 0=\"1\",1=1,2=1.0 0\n'
-            b'foo,hello=there 0=\"2\",1=2,2=2.0 3600000000000\n'
+            b'foo,hello=there 0=\"1\",1=1i,2=1.0 0\n'
+            b'foo,hello=there 0=\"2\",1=2i,2=2.0 3600000000000\n'
         )
 
         with requests_mock.Mocker() as m:
@@ -92,8 +92,8 @@ class TestDataFrameClient(unittest.TestCase):
                                  columns=["column_one", "column_two",
                                           "column_three"])
         expected = (
-            b"foo column_one=\"1\",column_three=1.0,column_two=1 0\n"
-            b"foo column_one=\"2\",column_three=2.0,column_two=2 "
+            b"foo column_one=\"1\",column_three=1.0,column_two=1i 0\n"
+            b"foo column_one=\"2\",column_three=2.0,column_two=2i "
             b"86400000000000\n"
         )
 
@@ -125,48 +125,48 @@ class TestDataFrameClient(unittest.TestCase):
             cli.write_points(dataframe, measurement, time_precision='h')
             self.assertEqual(m.last_request.qs['precision'], ['h'])
             self.assertEqual(
-                b'foo column_one="1",column_three=1.0,column_two=1 0\nfoo '
-                b'column_one="2",column_three=2.0,column_two=2 1\n',
+                b'foo column_one="1",column_three=1.0,column_two=1i 0\nfoo '
+                b'column_one="2",column_three=2.0,column_two=2i 1\n',
                 m.last_request.body,
             )
 
             cli.write_points(dataframe, measurement, time_precision='m')
             self.assertEqual(m.last_request.qs['precision'], ['m'])
             self.assertEqual(
-                b'foo column_one="1",column_three=1.0,column_two=1 0\nfoo '
-                b'column_one="2",column_three=2.0,column_two=2 60\n',
+                b'foo column_one="1",column_three=1.0,column_two=1i 0\nfoo '
+                b'column_one="2",column_three=2.0,column_two=2i 60\n',
                 m.last_request.body,
             )
 
             cli.write_points(dataframe, measurement, time_precision='s')
             self.assertEqual(m.last_request.qs['precision'], ['s'])
             self.assertEqual(
-                b'foo column_one="1",column_three=1.0,column_two=1 0\nfoo '
-                b'column_one="2",column_three=2.0,column_two=2 3600\n',
+                b'foo column_one="1",column_three=1.0,column_two=1i 0\nfoo '
+                b'column_one="2",column_three=2.0,column_two=2i 3600\n',
                 m.last_request.body,
             )
 
             cli.write_points(dataframe, measurement, time_precision='ms')
             self.assertEqual(m.last_request.qs['precision'], ['ms'])
             self.assertEqual(
-                b'foo column_one="1",column_three=1.0,column_two=1 0\nfoo '
-                b'column_one="2",column_three=2.0,column_two=2 3600000\n',
+                b'foo column_one="1",column_three=1.0,column_two=1i 0\nfoo '
+                b'column_one="2",column_three=2.0,column_two=2i 3600000\n',
                 m.last_request.body,
             )
 
             cli.write_points(dataframe, measurement, time_precision='u')
             self.assertEqual(m.last_request.qs['precision'], ['u'])
             self.assertEqual(
-                b'foo column_one="1",column_three=1.0,column_two=1 0\nfoo '
-                b'column_one="2",column_three=2.0,column_two=2 3600000000\n',
+                b'foo column_one="1",column_three=1.0,column_two=1i 0\nfoo '
+                b'column_one="2",column_three=2.0,column_two=2i 3600000000\n',
                 m.last_request.body,
             )
 
             cli.write_points(dataframe, measurement, time_precision='n')
             self.assertEqual(m.last_request.qs['precision'], ['n'])
             self.assertEqual(
-                b'foo column_one="1",column_three=1.0,column_two=1 0\n'
-                b'foo column_one="2",column_three=2.0,column_two=2 '
+                b'foo column_one="1",column_three=1.0,column_two=1i 0\n'
+                b'foo column_one="2",column_three=2.0,column_two=2i '
                 b'3600000000000\n',
                 m.last_request.body,
             )

--- a/influxdb/tests/server_tests/client_test_with_server.py
+++ b/influxdb/tests/server_tests/client_test_with_server.py
@@ -303,8 +303,8 @@ class CommonTests(ManyTestCasesWithServerMixin,
         self.test_write()
         time.sleep(1)
         rsp = self.cli.query('SELECT * FROM cpu_load_short', database='db')
-        self.assertListEqual([{'value': 0.64,
-                               'time': '2009-11-10T23:00:00Z'}],
+        self.assertListEqual([{'value': 0.64, 'time': '2009-11-10T23:00:00Z',
+                               "host": "server01", "region": "us-west"}],
                              list(rsp.get_points()))
 
     def test_write_points(self):
@@ -328,7 +328,8 @@ class CommonTests(ManyTestCasesWithServerMixin,
 
         self.assertEqual(
             list(rsp),
-            [[{'value': 0.64, 'time': '2009-11-10T23:00:00Z'}]]
+            [[{'value': 0.64, 'time': '2009-11-10T23:00:00Z',
+               "host": "server01", "region": "us-west"}]]
         )
 
         rsp2 = list(rsp.get_points())
@@ -337,7 +338,8 @@ class CommonTests(ManyTestCasesWithServerMixin,
 
         self.assertEqual(
             pt,
-            {'time': '2009-11-10T23:00:00Z', 'value': 0.64}
+            {'time': '2009-11-10T23:00:00Z', 'value': 0.64,
+             "host": "server01", "region": "us-west"}
         )
 
     @unittest.skip("Broken as of 0.9.0")
@@ -367,7 +369,8 @@ class CommonTests(ManyTestCasesWithServerMixin,
         lrsp = list(rsp)
 
         self.assertEqual(
-            [[{'value': 0.64, 'time': '2009-11-10T23:00:00Z'}]],
+            [[{'value': 0.64, 'time': '2009-11-10T23:00:00Z',
+               "host": "server01", "region": "us-west"}]],
             lrsp
         )
 
@@ -375,7 +378,8 @@ class CommonTests(ManyTestCasesWithServerMixin,
 
         self.assertEqual(
             rsp,
-            [[{'value': 33, 'time': '2009-11-10T23:01:35Z'}]]
+            [[{'value': 33, 'time': '2009-11-10T23:01:35Z',
+               "host": "server01", "region": "us-west"}]]
         )
 
     @unittest.skip("Broken as of 0.9.0")
@@ -678,6 +682,7 @@ class UdpTests(ManyTestCasesWithServerMixin,
 
         self.assertEqual(
             # this is dummy_points :
-            [{'value': 0.64, 'time': '2009-11-10T23:00:00Z'}],
+            [{'value': 0.64, 'time': '2009-11-10T23:00:00Z',
+              "host": "server01", "region": "us-west"}],
             list(rsp['cpu_load_short'])
         )

--- a/influxdb/tests/server_tests/influxdb.conf.template
+++ b/influxdb/tests/server_tests/influxdb.conf.template
@@ -10,6 +10,7 @@
 
 [data]
   dir = "{data_dir}"
+  wal-dir = "{wal_dir}"
   retention-auto-create = true
   retention-check-enabled = true
   retention-check-period = "10m0s"
@@ -54,7 +55,7 @@
   retention-policy = ""
   consistency-level = "one"
 
-[udp]
+[[udp]]
   enabled = {udp_enabled}
   bind-address = ":{udp_port}"
   database = "db"

--- a/influxdb/tests/server_tests/influxdb_instance.py
+++ b/influxdb/tests/server_tests/influxdb_instance.py
@@ -51,6 +51,7 @@ class InfluxDbInstance(object):
         conf_data = dict(
             meta_dir=os.path.join(tempdir, 'meta'),
             data_dir=os.path.join(tempdir, 'data'),
+            wal_dir=os.path.join(tempdir, 'wal'),
             cluster_dir=os.path.join(tempdir, 'state'),
             handoff_dir=os.path.join(tempdir, 'handoff'),
             logs_file=os.path.join(self.temp_dir_base, 'logs.txt'),

--- a/influxdb/tests/test_line_protocol.py
+++ b/influxdb/tests/test_line_protocol.py
@@ -20,6 +20,7 @@ class TestLineProtocol(unittest.TestCase):
                     "fields": {
                         "string_val": "hello!",
                         "int_val": 1,
+                        "float_val": 1.1,
                         "none_field": None,
                     }
                 }
@@ -29,7 +30,7 @@ class TestLineProtocol(unittest.TestCase):
         self.assertEqual(
             line_protocol.make_lines(data),
             'test,integer_tag=2,string_tag=hello '
-            'int_val=1,string_val="hello!"\n'
+            'float_val=1.1,int_val=1i,string_val="hello!"\n'
         )
 
     def test_string_val_newline(self):


### PR DESCRIPTION
Building off of #232, this fixes the tests and ensures that everything works. @xbs13's code was checking if the value was an int after it had been str'd, so I moved it earlier in the call stack.

On a side note, it appears there was a change in 0.9.3-rc3 (possibly a previous rc) that causes the tags to be returned when calling query. I didn't look into it much, just changed the tests to handle the results coming back.