### PR TITLE
Raise InfluxDBServerError for server error instead of InfluxDBClientError

### DIFF
--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -202,8 +202,10 @@ localhost:8086/databasename', timeout=5, udp_port=159)
         :type expected_response_code: int
         :returns: the response from the request
         :rtype: :class:`requests.Response`
+        :raises InfluxDBServerError: if the response code is any server error
+            code (5xx)
         :raises InfluxDBClientError: if the response code is not the
-            same as `expected_response_code`
+            same as `expected_response_code` and is not a server error code
         """
         url = "{0}/{1}".format(self._baseurl, url)
 
@@ -237,7 +239,9 @@ localhost:8086/databasename', timeout=5, udp_port=159)
                 else:
                     raise e
 
-        if response.status_code == expected_response_code:
+        if response.status_code >= 500 and response.status_code < 600:
+            raise InfluxDBServerError(response.content)
+        elif response.status_code == expected_response_code:
             return response
         else:
             raise InfluxDBClientError(response.content, response.status_code)


### PR DESCRIPTION
Shouldn't  InfluxDBServerError be raised when InfluxDB fail to serve a request (e.g. HTTP status is 5xx) instead of InfluxDBClientError.

I need this distinction, because I've some code retry writing when server fail (not started/starting) but discard malformed input. E.g. :

```
try:
    client.write_points(...)
except InfluxDBClientError:
    # do not retry this write, it means malformed points
except (InfluxDBServerError, ConnectionError):
   # do retry this write, it means server down/starting
```

This would also be valuable for InfluxDBClusterClient, who should go to next server if one of the server fail.

One case were InfluxDB return a 500 error code (that is not due to bad input) is during startup of single node, before metastore initialization. In this case I got the error ```metastore database error: no leader```. This is obviously only a temporary error and few seconds later server is available.