### PR TITLE
Fix issue 237

### DIFF
--- a/influxdb/tests/client_test.py
+++ b/influxdb/tests/client_test.py
@@ -337,12 +337,13 @@ class TestInfluxDBClient(unittest.TestCase):
             cli.write_points_with_precision([])
 
     def test_query(self):
-        example_response = \
-            '{"results": [{"series": [{"measurement": "sdfsdfsdf", ' \
-            '"columns": ["time", "value"], "values": ' \
-            '[["2009-11-10T23:00:00Z", 0.64]]}]}, {"series": ' \
-            '[{"measurement": "cpu_load_short", "columns": ["time", "value"], ' \
+        example_response = (
+            '{"results": [{"series": [{"measurement": "sdfsdfsdf", '
+            '"columns": ["time", "value"], "values": '
+            '[["2009-11-10T23:00:00Z", 0.64]]}]}, {"series": '
+            '[{"measurement": "cpu_load_short", "columns": ["time", "value"], '
             '"values": [["2009-11-10T23:00:00Z", 0.64]]}]}]}'
+        )
 
         with requests_mock.Mocker() as m:
             m.register_uri(

--- a/influxdb/tests/client_test.py
+++ b/influxdb/tests/client_test.py
@@ -805,6 +805,28 @@ class TestInfluxDBClusterClient(unittest.TestCase):
         self.assertEqual(1, len(cluster.clients))
         self.assertEqual(2, len(cluster.bad_clients))
 
+    def test_switch_database(self):
+        c = InfluxDBClusterClient(hosts=self.hosts,
+                                  shuffle=True,
+                                  client_base_class=InfluxDBClient)
+        self.assertEqual(3, len(c.clients))
+        self.assertEqual(0, len(c.bad_clients))
+        map(lambda x: self.assertEqual(None, x._database), c.clients)
+        c.switch_database('database')
+        map(lambda x: self.assertEqual('database', x._database), c.clients)
+
+    def test_switch_user(self):
+        c = InfluxDBClusterClient(hosts=self.hosts,
+                                  shuffle=True,
+                                  client_base_class=InfluxDBClient)
+        self.assertEqual(3, len(c.clients))
+        self.assertEqual(0, len(c.bad_clients))
+        map(lambda x: self.assertEqual('root', x._username), c.clients)
+        map(lambda x: self.assertEqual('root', x._password), c.clients)
+        c.switch_user('username', 'password')
+        map(lambda x: self.assertEqual('username', x._username), c.clients)
+        map(lambda x: self.assertEqual('password', x._password), c.clients)
+
     def test_dsn(self):
         cli = InfluxDBClusterClient.from_DSN(self.dsn_string)
         self.assertEqual(2, len(cli.clients))


### PR DESCRIPTION
This should enable the cluster client to properly switch databases and user credentials for all clients in the cluster, not just a random one. It doesn't look pretty and actually I'd like to suggest an alternative implementation of the InfluxDBClusterClient which will actually inherit the InfluxDBClient and instead of maintaining a list of InfluxDBClients, we can just keep the list of (host, port) tuples and alternate those on each request. This way we win a few things:
- Less memory usage, obviously. There's no need to create 3 InfluxDBClient objects when we can get away with a single one;
- We get access to all attributes of the InfluxDBClient  (not just the callable ones);
- Docstrings available for all methods. It also means that auto-completion will be available for developers;
- Easier maintenance and avoiding bugs similar to this one.

Since some users of the library might be using the `clients` attribute of the cluster client current implementation, we can make the new one backwards compatible by having a list with only one element (self) as the `clients` attribute, i.e. ```self.clients = [self]```

@aviau , @gst, @areski , any thoughts on that?
