### PR TITLE
Avoid mutable value for defaults of functions

### DIFF
--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -280,7 +280,7 @@ localhost:8086/databasename', timeout=5, udp_port=159)
 
     def query(self,
               query,
-              params={},
+              params=None,
               epoch=None,
               expected_response_code=200,
               database=None,
@@ -307,6 +307,9 @@ localhost:8086/databasename', timeout=5, udp_port=159)
         :returns: the queried data
         :rtype: :class:`~.ResultSet`
         """
+        if params is None:
+            params = {}
+
         params['q'] = query
         params['db'] = database or self._database
 


### PR DESCRIPTION
Remove mutable default from ```InfluxDBClient.query``` method.

params used a dictionary as default value. That dict contains the actual query. Since default are shared... across whole process, this caused race condition when used in multi-threading program : some thread got response for another thread query !


I did a pass on other function, only ```InfluxDBClusterClient.__init__``` is using a mutable default for ```hosts``` ([link to code](https://github.com/influxdb/influxdb-python/blob/2ace816acd802b7e2dfb3398354df15f2663e53e/influxdb/client.py#L740)). But since it doesn't modify it and using a list makes code a bit more readable than tuple, I didn't changed it.