### PR TITLE
add option to use Requests http(s) proxy

### DIFF
--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -55,6 +55,8 @@ class InfluxDBClient(object):
     :type use_udp: int
     :param udp_port: UDP port to connect to InfluxDB, defaults to 4444
     :type udp_port: int
+    :param proxies: HTTP(S) proxy to use for Requests, defaults to {}
+    :type proxies: dict
     """
 
     def __init__(self,
@@ -68,6 +70,7 @@ class InfluxDBClient(object):
                  timeout=None,
                  use_udp=False,
                  udp_port=4444,
+                 proxies=None,
                  ):
         """Construct a new InfluxDBClient object."""
         self._host = host
@@ -89,6 +92,11 @@ class InfluxDBClient(object):
 
         if ssl is True:
             self._scheme = "https"
+
+        if proxies is None:
+            self._proxies = {}
+        else:
+            self._proxies = proxies
 
         self._baseurl = "{0}://{1}:{2}".format(
             self._scheme,
@@ -229,6 +237,7 @@ localhost:8086/databasename', timeout=5, udp_port=159)
                     params=params,
                     data=data,
                     headers=headers,
+                    proxies=self._proxies,
                     verify=self._verify_ssl,
                     timeout=self._timeout
                 )


### PR DESCRIPTION
The influxdb-python client does not have support for a web proxy although
the Requests library provides the possibility to use a web proxy for both
http and https requests.
This PR (optionally) adds the feature to use a http(s) proxy by adding
an additional parameter to InfluxDBClient initialization called´"proxies".
This parameter expects that a dict is provided. If this is not set it will
default to { }.
The syntax for the dict is the same as specified in Requests docs:
http://docs.python-requests.org/en/latest/user/advanced/#proxies
proxies = {
  "http": "http://10.10.1.10:3128",
  "https": "http://10.10.1.10:1080",
}