### PR TITLE
Create db only if doesn't exist yet

### DIFF
--- a/influxdb/client.py
+++ b/influxdb/client.py
@@ -460,7 +460,7 @@ localhost:8086/databasename', timeout=5, udp_port=159)
         :param dbname: the name of the database to create
         :type dbname: str
         """
-        self.query("CREATE DATABASE \"%s\"" % dbname)
+        self.query("CREATE DATABASE IF NOT EXISTS \"%s\"" % dbname)
 
     def drop_database(self, dbname):
         """Drop a database from InfluxDB.


### PR DESCRIPTION
This allows to run

    CREATE DATABASE IF NOT EXISTS "db_name";

so that one does not need to check it before creation.